### PR TITLE
Allow binding to multiple routing keys.

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -29,9 +29,13 @@ class Sneakers::Queue
     handler = @handler_klass.new(@channel)
 
     routing_key = @opts[:routing_key] || @name
+    routing_keys = routing_key.respond_to?(:each) ? routing_key : [routing_key]
 
     queue = @channel.queue(@name, :durable => @opts[:durable])
-    queue.bind(@exchange, :routing_key => routing_key)
+
+    routing_keys.each do |key|
+      queue.bind(@exchange, :routing_key => key)
+    end
 
     @consumer = queue.subscribe(:block => false, :ack => @opts[:ack]) do | hdr, props, msg | 
       worker.do_work(hdr, props, msg, handler)


### PR DESCRIPTION
Simple patch to allow an array of routing keys to be passed into the queue settings. This allows workers to respond to  selectively respond to multiple topics on a topic exchange. 

E.g.

``` ruby
class Processor
  include Sneakers::Worker
  from_queue :log_processor,
             exchange: 'topic_logs',
             exchange_type: 'topic',
             routing_key: ['kern.*', '*.critical']

  def work(msg)
    err = JSON.parse(msg)
    if err["type"] == "error"
      $redis.incr "processor:#{err["error"]}"
    end

    ack!
  end
end
```
