### PR TITLE
Bump Bunny to 1.1.3+

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_dependency "serverengine"
-  gem.add_dependency "bunny", "~> 1.1.0"
+  gem.add_dependency "bunny", "~> 1.1.3"
   gem.add_dependency "thread"
   gem.add_dependency "thor"
 


### PR DESCRIPTION
[Significantly lower latency](https://github.com/ruby-amqp/bunny/pull/187) for workloads that involve frequently sent small messages.
