### PR TITLE
Hooks after message is processed

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -85,6 +85,7 @@ module Sneakers
             handler.noop(delivery_info, metadata, msg)
           end
           metrics.increment("work.#{self.class.name}.handled.#{res || 'noop'}")
+          trigger_hook(res)
         end
 
         metrics.increment("work.#{self.class.name}.ended")
@@ -121,6 +122,12 @@ module Sneakers
 
     def worker_trace(msg)
       logger.debug(log_msg(msg))
+    end
+
+    def trigger_hook(result)
+      hooks = @opts[:hooks]
+      hook_name = "on_#{result}".to_sym
+      hooks[hook_name].call if hooks[hook_name]
     end
 
     def self.included(base)


### PR DESCRIPTION
Created the following hooks that are executed after the message is processed:
- on_ack
- on_timeout
- on_error
- on_reject
- on_requeue

```ruby
Sneakers.configure(hooks: { on_timeout: ->{ puts "Timeout happened" })
```
or
```ruby
class TestWorker
  include Sneakers::Worker

  from_queue 'test', hooks: { on_timeout: ->{ puts "Timeout happened" } }

  def work(msg)
  end
end
```

Any tips on how to properly test this?