### PR TITLE
Add support for namespaced workers (e.g. Foo::Bar)

### DIFF
--- a/lib/sneakers/support/utils.rb
+++ b/lib/sneakers/support/utils.rb
@@ -6,7 +6,7 @@ class Sneakers::Utils
     missing_workers = []
     workers = (workerstring || '').split(',').map do |k|
       begin
-        w = Object.const_get(k)
+        w = k.split('::').inject(Kernel){|s, c| s.const_get(c)}
       rescue
         missing_workers << k
       end

--- a/spec/sneakers/support/utils_spec.rb
+++ b/spec/sneakers/support/utils_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'sneakers'
+
+describe Sneakers::Utils do
+  describe '::parse_workers' do
+    before(:all) do
+      class Foo; end
+      class Bar; end
+      class Baz
+        class Quux; end
+        class Corge; end
+      end
+    end
+
+    describe 'given a single class name' do
+      describe 'without namespace' do
+        it 'returns the worker class name' do
+          Sneakers::Utils.parse_workers('Foo').must_equal([[Foo],[]])
+        end
+      end
+
+      describe 'with namespace' do
+        it 'returns the worker class name' do
+          Sneakers::Utils.parse_workers('Baz::Quux').must_equal([[Baz::Quux],[]])
+        end
+      end
+    end
+
+    describe 'given a list of class names' do
+      describe 'without namespaces' do
+        it 'returns all worker class names' do
+          Sneakers::Utils.parse_workers('Foo,Bar').must_equal([[Foo,Bar],[]])
+        end
+      end
+
+      describe 'with namespaces' do
+        it 'returns all worker class names' do
+          workers = Sneakers::Utils.parse_workers('Baz::Quux,Baz::Corge')
+          workers.must_equal([[Baz::Quux,Baz::Corge],[]])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Originally I had the code written like

``` ruby
w = if k.respond_to?(:constantize)
  k.constantize
else
  k.split('::').inject(Kernel){|s, c| s.const_get(c)}
end
```

so it could lean on ActiveSupport/Rails if available, but wasn't sure how to properly cover that in the test code so I just took it out.
