### PR TITLE
Sneakers' Publishers were not preserving vhost, so I added the vhost when creating the Bunny connection in the Publisher

### DIFF
--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -18,7 +18,7 @@ module Sneakers
     attr_reader :exchange
 
     def ensure_connection!
-      @bunny = Bunny.new(@opts[:amqp], heartbeat: @opts[:heartbeat])
+      @bunny = Bunny.new(@opts[:amqp], heartbeat: @opts[:heartbeat], vhost: @opts[:vhost])
       @bunny.start
       @channel = @bunny.create_channel
       @exchange = @channel.exchange(@opts[:exchange], type: @opts[:exchange_type], durable: @opts[:durable])


### PR DESCRIPTION
## This pull request should resolve the issue I submitted a couple of weeks back:

https://github.com/jondot/sneakers/issues/43
