### PR TITLE
Allow passing of arguements to RMQ plugins

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -31,7 +31,7 @@ class Sneakers::Queue
     routing_key = @opts[:routing_key] || @name
     routing_keys = [*routing_key]
 
-    queue = @channel.queue(@name, :durable => @opts[:durable])
+    queue = @channel.queue(@name, :durable => @opts[:durable], :arguments => @opts[:arguments])
 
     routing_keys.each do |key|
       queue.bind(@exchange, :routing_key => key)


### PR DESCRIPTION
This change allows for the passing of plugin arguments for RMQ.  For example we're using it in conjunction with the priority plugin.

``` ruby
require 'sneakers'

class Processor
  include Sneakers::Worker
  from_queue :priority_test , :arguments => {'x-max-priority' => 255}

  def work(msg)
    logger.info msg
  end
end
```
