### PR TITLE
Respect RABBITMQ_URL if it's set.

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -20,28 +20,31 @@ require 'sneakers/publisher'
 
 module Sneakers
 
+  rabbitmq_url   = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+  rabbitmq_vhost = URI.parse(rabbitmq_url).path.to_s.gsub(/^\//, '')
+  rabbitmq_vhost = '/' if rabbitmq_vhost == ''
+
   DEFAULTS = {
     # runner
     :runner_config_file => nil,
-    :metrics => nil,
-    :daemonize => false,
+    :metrics            => nil,
+    :daemonize          => false,
     :start_worker_delay => 0.2,
-    :workers => 4,
-    :log  => STDOUT,
-    :pid_path => 'sneakers.pid',
-
-    #workers
-    :timeout_job_after => 5,
-    :prefetch => 10,
-    :threads => 10,
-    :durable => true,
-    :ack => true,
-    :heartbeat => 2,
-    :amqp => 'amqp://guest:guest@localhost:5672',
-    :vhost => '/',
-    :exchange => 'sneakers',
-    :exchange_type => :direct,
-    :hooks => {}
+    :workers            => 4,
+    :log                => STDOUT,
+    :pid_path           => 'sneakers.pid',
+    # workers
+    :timeout_job_after  => 5,
+    :prefetch           => 10,
+    :threads            => 10,
+    :durable            => true,
+    :ack                => true,
+    :heartbeat          => 2,
+    :amqp               => rabbitmq_url,
+    :vhost              => rabbitmq_vhost,
+    :exchange           => 'sneakers',
+    :exchange_type      => :direct,
+    :hooks              => {}
   }.freeze
 
   Config = DEFAULTS.dup


### PR DESCRIPTION
This change makes Sneakers respect the `RABBITMQ_URL` environment variable. This is the same variable that Bunny will look for.

Since the RabbitMQ virtual host can be set in the URL, this change makes makes it look for the virtualhost there rather than defaulting to '/'. 

At present in Sneakers, it's possible to set the amqp_url to a value that includes a virtual host, but unless you explicitly set the virtualhost value as well, Sneakers will still use "/". This caused me a bit of confusion at first, as I was wondering why my URL with a virtual host wasn't sufficient to set that value in Sneakers.

Note that there are no tests in place for this, since at present the DEFAULTS hash is initialized at compile-time and frozen, which means it's too late to set the ENV var in the tests. I think it would be a good idea to implement a Sneakers::Configuration class with accessor methods for the config variables Sneakers uses; I've done something similar [in friendly_id](https://github.com/norman/friendly_id/blob/master/lib/friendly_id/configuration.rb), but didn't want to send you too large a pull request unless you agreed with the idea.
