### PR TITLE
Allow publishing with all options accepted by Bunny

### DIFF
--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -5,12 +5,14 @@ module Sneakers
       @opts = Sneakers::Config.merge(opts)
     end
 
-    def publish(msg, routing)
+    def publish(msg, options = {})
       @mutex.synchronize do
         ensure_connection! unless connected?
       end
-      Sneakers.logger.info("publishing <#{msg}> to [#{routing[:to_queue]}]")
-      @exchange.publish(msg, routing_key: routing[:to_queue], persistence: routing[:persistence])
+      to_queue = options.delete(:to_queue)
+      options[:routing_key] ||= to_queue
+      Sneakers.logger.info {"publishing <#{msg}> to [#{options[:routing_key]}]"}
+      @exchange.publish(msg, options)
     end
 
     private

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -34,9 +34,11 @@ module Sneakers
     def reject!; :reject; end
     def requeue!; :requeue; end
 
-    def publish(msg, routing)
-      return unless routing[:to_queue]
-      @queue.exchange.publish(msg, :routing_key => routing[:to_queue])
+    def publish(msg, opts)
+      to_queue = opts.delete(:to_queue)
+      opts[:routing_key] ||= to_queue
+      return unless opts[:routing_key]
+      @queue.exchange.publish(msg, opts)
     end
 
     def do_work(hdr, props, msg, handler)

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -25,6 +25,17 @@ describe Sneakers::Publisher do
       p.publish('test msg', to_queue: 'downloads', persistence: true)
     end
 
+    it 'should publish with arbitrary metadata specified' do
+      xchg = Object.new
+      mock(xchg).publish('test msg', routing_key: 'downloads', expiration: 1, headers: {foo: 'bar'})
+
+      p = Sneakers::Publisher.new
+      p.instance_variable_set(:@exchange, xchg)
+
+      mock(p).ensure_connection! {}
+      p.publish('test msg', to_queue: 'downloads', expiration: 1, headers: {foo: 'bar'})
+    end
+
     it 'should not reconnect if already connected' do
       xchg = Object.new
       mock(xchg).publish('test msg', routing_key: 'downloads')

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -304,6 +304,12 @@ describe Sneakers::Worker do
       mock(@exchange).publish('msg', :routing_key => 'target').once
       w.do_work(nil, nil, 'msg', nil)
     end
+
+    it 'should be able to publish arbitrary metadata' do
+      w = PublishingWorker.new(@queue, TestPool.new)
+      mock(@exchange).publish('msg', :routing_key => 'target', :expiration => 1).once
+      w.publish 'msg', :to_queue => 'target', :expiration => 1
+    end
   end
 
 


### PR DESCRIPTION
Sneakers currently cherry-picks out a few publishing options to pass to Rabbit, and discards all the rest. This makes it impossible to perform some useful operations, such as adding meta data to a message, or settings its TTL. Since Sneakers goes out of its way to allow workers to ready from the metadata sent by Rabbit, it doesn't makes sense for it to forbid its workers from publishing metadata. This change is backwards compatible with the current Sneakers because it just passes through all the options to Bunny.
