### PR TITLE
Rename worker arguments to match the names used by Bunny

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -37,8 +37,8 @@ class Sneakers::Queue
       queue.bind(@exchange, :routing_key => key)
     end
 
-    @consumer = queue.subscribe(:block => false, :ack => @opts[:ack]) do | hdr, props, msg | 
-      worker.do_work(hdr, props, msg, handler)
+    @consumer = queue.subscribe(:block => false, :ack => @opts[:ack]) do | delivery_info, metadata, msg |
+      worker.do_work(delivery_info, metadata, msg, handler)
     end
     nil
   end


### PR DESCRIPTION
This changes the names of the variables passed to Sneakers workers, so that they match the names used in Bunny. Reading the source code of both libraries is confusing because of the arbitrarily different names.

It also makes the code seem odd when delivery_info is referred to as `hdrs`, because that implies they are "headers", but the props (now metadata) argument contains a "headers" key. For example:

``` ruby
def work_with_params(msg, hdrs, props)
  headers = props[:headers] # if these are "headers", what are "hdrs"?
  ...
end
```
