### PR TITLE
Delegate fetch method to hash in configuration

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -2,7 +2,7 @@ module Sneakers
   class Configuration
 
     extend Forwardable
-    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==
+    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==, :fetch
 
     DEFAULTS = {
       # runner


### PR DESCRIPTION
The runner uses the fetch method, so we need to delegate it as well as the others.
