### PR TITLE
Fix problem with ServerEngine::Daemon initializer

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -2,7 +2,7 @@ module Sneakers
   class Configuration
 
     extend Forwardable
-    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==, :, :fetch
+    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==, :fetch
 
     DEFAULTS = {
       # runner


### PR DESCRIPTION
Without this fix I get next exception:

```
rake aborted!
NoMethodError: undefined method `fetch' for #<Sneakers::Configuration:0x007fe897ed5760>
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine/daemon.rb:31:in `initialize'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine.rb:50:in `new'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine.rb:50:in `create'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-cf86a68e0a3a/lib/sneakers/runner.rb:11:in `run'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-cf86a68e0a3a/lib/sneakers/tasks.rb:32:in `block (2 levels) in <top (required)>'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bin/ruby_noexec_wrapper:14:in `eval'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bin/ruby_noexec_wrapper:14:in `<main>'
Tasks: TOP => sneakers:run
```
