### PR TITLE
New exception with Sneakers::Configuration

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -2,7 +2,7 @@ module Sneakers
   class Configuration
 
     extend Forwardable
-    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==, :fetch
+    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==, :fetch, :delete
 
     DEFAULTS = {
       # runner


### PR DESCRIPTION
```
NoMethodError: undefined method `delete' for #<Sneakers::Configuration:0x007fddaf664da8>
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-5aa21aa50074/lib/sneakers/runner.rb:58:in `block in reload_config!'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-5aa21aa50074/lib/sneakers/runner.rb:57:in `each'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-5aa21aa50074/lib/sneakers/runner.rb:57:in `reload_config!'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-5aa21aa50074/lib/sneakers/runner.rb:11:in `block in run'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine/config_loader.rb:39:in `call'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine/config_loader.rb:39:in `reload_config'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine/config_loader.rb:32:in `initialize'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine/daemon.rb:29:in `initialize'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine.rb:50:in `new'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/gems/serverengine-1.5.9/lib/serverengine.rb:50:in `create'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-5aa21aa50074/lib/sneakers/runner.rb:11:in `run'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bundler/gems/sneakers-5aa21aa50074/lib/sneakers/tasks.rb:32:in `block (2 levels) in <top (required)>'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bin/ruby_noexec_wrapper:14:in `eval'
/Users/arion/.rvm/gems/ruby-1.9.3-p545/bin/ruby_noexec_wrapper:14:in `<main>'
```
