### PR TITLE
Bump Bunny to 1.6.3

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine'
-  gem.add_dependency 'bunny', '~> 1.1.3'
+  gem.add_dependency 'bunny', '~> 1.6.3'
   gem.add_dependency 'thread'
   gem.add_dependency 'thor'
 


### PR DESCRIPTION
It's really unfortunate that we only do this after the 1.0 release but better
late than never.
