### PR TITLE
Require forwardable.

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Sneakers
   class Configuration
 


### PR DESCRIPTION
Forwardable module has been used in the `Configuration` class but was never explicitly required.
