### PR TITLE
Quiet down heartbeat logging

### DIFF
--- a/lib/sneakers/workergroup.rb
+++ b/lib/sneakers/workergroup.rb
@@ -28,7 +28,7 @@ module Sneakers
       # end per worker
       #
       until @stop_flag.wait_for_set(10.0)
-        Sneakers.logger.info("Heartbeat: running threads [#{Thread.list.count}]")
+        Sneakers.logger.debug("Heartbeat: running threads [#{Thread.list.count}]")
         # report aggregated stats?
       end
 


### PR DESCRIPTION
I'd like to reduce the importance of the "Heartbeat: running threads" message. It's not particularly informative, and it's producing a great deal of superfluous log volume for me, especially on relatively quiet hosts.
