### PR TITLE
Switch to :manual_ack to remove deprecation warning.

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -46,7 +46,7 @@ class Sneakers::Queue
     handler_klass = worker.opts[:handler] || Sneakers::CONFIG[:handler]
     handler = handler_klass.new(@channel, queue, worker.opts)
 
-    @consumer = queue.subscribe(:block => false, :ack => @opts[:ack]) do | delivery_info, metadata, msg |
+    @consumer = queue.subscribe(:block => false, :manual_ack => @opts[:ack]) do | delivery_info, metadata, msg |
       worker.do_work(delivery_info, metadata, msg, handler)
     end
     nil

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -44,7 +44,7 @@ describe Sneakers::Queue do
       q = Sneakers::Queue.new("downloads", queue_vars)
 
       mock(@mkqueue).bind(@mkex, :routing_key => "downloads")
-      mock(@mkqueue).subscribe(:block => false, :ack => true)
+      mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
 
       q.subscribe(@mkworker)
     end
@@ -56,7 +56,7 @@ describe Sneakers::Queue do
 
       mock(@mkqueue).bind(@mkex, :routing_key => "alpha")
       mock(@mkqueue).bind(@mkex, :routing_key => "beta")
-      mock(@mkqueue).subscribe(:block => false, :ack => true)
+      mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
 
       q.subscribe(@mkworker)
     end
@@ -80,7 +80,7 @@ describe Sneakers::Queue do
       q = Sneakers::Queue.new("test_nondurable", queue_vars)
 
       mock(@mkqueue_nondurable).bind(@mkex, :routing_key => "test_nondurable")
-      mock(@mkqueue_nondurable).subscribe(:block => false, :ack => true)
+      mock(@mkqueue_nondurable).subscribe(:block => false, :manual_ack => true)
 
       q.subscribe(@mkworker)
       myqueue = q.instance_variable_get(:@queue)


### PR DESCRIPTION
Bunny is throwing a deprecation warning when using the :ack option for queues.  It recommends switching to :manual_ack.  This pull request fixes the deprecation warning.  All tests seem to pass, and I haven't noticed any problems with this.
