### PR TITLE
Bump Bunny to 1.7.0

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine'
-  gem.add_dependency 'bunny', '~> 1.6.3'
+  gem.add_dependency 'bunny', '~> 1.7.0'
   gem.add_dependency 'thread'
   gem.add_dependency 'thor'
 


### PR DESCRIPTION
[Release notes](http://blog.rubyrabbitmq.info/blog/2015/02/05/bunny-1-dot-7-0-is-released/).