### PR TITLE
Making Travis CI badge clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Visit the [wiki](https://github.com/jondot/sneakers/wiki) for
 complete docs.
 
 
-![](https://travis-ci.org/jondot/sneakers.svg)
+[![Build Status](https://travis-ci.org/jondot/sneakers.svg?branch=master)](https://travis-ci.org/jondot/sneakers)
 
 
 ## Installation


### PR DESCRIPTION
With this it should be possible to click the current build state and jump to the right place on travis-ci.org. One hopes