### PR TITLE
Allow Sneakers to use default exchange

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -22,7 +22,8 @@ class Sneakers::Queue
     @channel = @bunny.create_channel
     @channel.prefetch(@opts[:prefetch])
 
-    @exchange = @channel.exchange(@opts[:exchange],
+    exchange_name = @opts[:exchange]
+    @exchange = @channel.exchange(exchange_name,
                                   :type => @opts[:exchange_type],
                                   :durable => @opts[:durable])
 
@@ -35,8 +36,10 @@ class Sneakers::Queue
     queue_durable = @opts[:queue_durable].nil? ? @opts[:durable] : @opts[:queue_durable]
     queue = @channel.queue(@name, :durable => queue_durable, :arguments => @opts[:arguments])
 
-    routing_keys.each do |key|
-      queue.bind(@exchange, :routing_key => key)
+    if exchange_name.length > 0
+      routing_keys.each do |key|
+        queue.bind(@exchange, :routing_key => key)
+      end
     end
 
     # NOTE: we are using the worker's options. This is necessary so the handler

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov-rcov-text'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
+  gem.add_development_dependency 'guard'
 end
 

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -8,35 +8,38 @@ describe Sneakers::Queue do
     Sneakers.configure
   end
 
-  describe "#subscribe" do
-    let :queue_vars do
-      {
-        :prefetch => 25,
-        :durable => true,
-        :ack => true,
-        :heartbeat => 2,
-        :vhost => '/',
-        :exchange => "sneakers",
-        :exchange_type => :direct
-      }
-    end
+  let :queue_vars do
+    {
+      :prefetch => 25,
+      :durable => true,
+      :ack => true,
+      :heartbeat => 2,
+      :vhost => '/',
+      :exchange => "sneakers",
+      :exchange_type => :direct
+    }
+  end
 
+  before do
+    @mkbunny = Object.new
+    @mkchan = Object.new
+    @mkex = Object.new
+    @mkqueue = Object.new
+    @mkqueue_nondurable = Object.new
+    @mkworker = Object.new
+
+    mock(@mkbunny).start {}
+    mock(@mkbunny).create_channel{ @mkchan }
+    mock(Bunny).new(anything, :vhost => '/', :heartbeat => 2){ @mkbunny }
+
+    mock(@mkchan).prefetch(25)
+
+    stub(@mkworker).opts { { :exchange => 'test-exchange' } }
+  end
+
+  describe "#subscribe with sneakers exchange" do
     before do
-      @mkbunny = Object.new
-      @mkchan = Object.new
-      @mkex = Object.new
-      @mkqueue = Object.new
-      @mkqueue_nondurable = Object.new
-      @mkworker = Object.new
-
-      mock(@mkbunny).start {}
-      mock(@mkbunny).create_channel{ @mkchan }
-      mock(Bunny).new(anything, :vhost => '/', :heartbeat => 2){ @mkbunny }
-
-      mock(@mkchan).prefetch(25)
       mock(@mkchan).exchange("sneakers", :type => :direct, :durable => true){ @mkex }
-
-      stub(@mkworker).opts { { :exchange => 'test-exchange' } }
     end
 
     it "should setup a bunny queue according to configuration values" do
@@ -84,6 +87,30 @@ describe Sneakers::Queue do
 
       q.subscribe(@mkworker)
       myqueue = q.instance_variable_get(:@queue)
+    end
+  end
+
+  describe "#subscribe with default exchange" do
+    before do
+      # expect default exchange
+      queue_vars[:exchange] = ""
+      mock(@mkchan).exchange("", :type => :direct, :durable => true){ @mkex }
+    end
+
+    it "does not bind to exchange" do
+      mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
+      @handler = Object.new
+      worker_opts = { :handler => @handler }
+      stub(@mkworker).opts { worker_opts }
+      mock(@handler).new(@mkchan, @mkqueue, worker_opts).once
+
+      stub(@mkqueue).bind do
+        raise "bind should not be called"
+      end
+
+      stub(@mkqueue).subscribe
+      q = Sneakers::Queue.new("downloads", queue_vars)
+      q.subscribe(@mkworker)
     end
   end
 end


### PR DESCRIPTION
This PR fixes following issue:

RabbitMQ does not allow to bind queues to default exchange. But Sneakers always tries to bind queue to an exchange. This means that Sneakers can't be used with default exchange. See https://github.com/jondot/sneakers/issues/105