### PR TITLE
Cast exception class to String in maxretry handler

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -140,7 +140,7 @@ module Sneakers
             payload: Base64.encode64(msg.to_s)
           }.tap do |hash|
             if reason.is_a?(Exception)
-              hash[:error_class] = reason.class
+              hash[:error_class] = reason.class.to_s
               hash[:error_message] = "#{reason}"
               if reason.backtrace
                 hash[:backtrace] = reason.backtrace.take(10).join(', ')


### PR DESCRIPTION
Because for now it always reports `{}`