### PR TITLE
parse vhost from amqp url specified in Sneakers.configure

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -4,7 +4,7 @@ module Sneakers
   class Configuration
 
     extend Forwardable
-    def_delegators :@hash, :to_hash, :[], :[]=, :merge!, :==, :fetch, :delete
+    def_delegators :@hash, :to_hash, :[], :[]=, :==, :fetch, :delete
 
     DEFAULTS = {
       # runner
@@ -37,6 +37,16 @@ module Sneakers
       @hash = DEFAULTS.dup
       @hash[:amqp]  = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
       @hash[:vhost] = AMQ::Settings.parse_amqp_url(@hash[:amqp]).fetch(:vhost, '/')
+    end
+
+    def merge!(hash)
+      # parse vhost from amqp if vhost is not specified explicitly
+      if hash[:vhost].nil? && !hash[:amqp].nil?
+        hash = hash.dup
+        hash[:vhost] = AMQ::Settings.parse_amqp_url(hash[:amqp]).fetch(:vhost, '/')
+      end
+
+      @hash.merge!(hash)
     end
 
     def merge(hash)

--- a/spec/sneakers/configuration_spec.rb
+++ b/spec/sneakers/configuration_spec.rb
@@ -32,6 +32,39 @@ describe Sneakers::Configuration do
     end
   end
 
+  it 'should parse vhost from amqp option' do
+    env_url = 'amqp://foo:bar@localhost:5672/foobarvhost'
+    with_env('RABBITMQ_URL', env_url) do
+      url = 'amqp://foo:bar@localhost:5672/testvhost'
+      config = Sneakers::Configuration.new
+      config.merge!({ :amqp => url })
+      config[:vhost].must_equal 'testvhost'
+    end
+  end
+
+  it 'should not parse vhost from amqp option if vhost is specified explicitly' do
+    url = 'amqp://foo:bar@localhost:5672/foobarvhost'
+    config = Sneakers::Configuration.new
+    config.merge!({ :amqp => url, :vhost => 'test_host' })
+    config[:vhost].must_equal 'test_host'
+  end
+
+  it 'should use vhost option if it is specified' do
+    url = 'amqp://foo:bar@localhost:5672/foobarvhost'
+    with_env('RABBITMQ_URL', url) do
+      config = Sneakers::Configuration.new
+      config.merge!({ :vhost => 'test_host' })
+      config[:vhost].must_equal 'test_host'
+    end
+  end
+
+  it 'should use default vhost if vhost is not specified in amqp option' do
+    url = 'amqp://foo:bar@localhost:5672'
+    config = Sneakers::Configuration.new
+    config.merge!({ :amqp => url })
+    config[:vhost].must_equal '/'
+  end
+
   def with_env(key, value)
     old_value = ENV[key]
     ENV[key] = value


### PR DESCRIPTION
This fixes https://github.com/jondot/sneakers/issues/89.

Before this PR vhost from amqp URL would be ignored when using `Sneakers.configure`:
```
# vhost would not be set
Sneakers.configure({ amqp: "amqp://foo:bar@localhost:5672/foobarvhost" })
```

This PR updates `Configuration` to parse vhost if it is part of amqp URL