### PR TITLE
Properly close mysql connections on job timeout

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -50,7 +50,7 @@ module Sneakers
 
         begin
           metrics.increment("work.#{self.class.name}.started")
-          Timeout.timeout(@timeout_after) do
+          Timeout.timeout(@timeout_after, Timeout::Error) do
             metrics.timing("work.#{self.class.name}.time") do
               if @call_with_params
                 res = work_with_params(msg, delivery_info, metadata)


### PR DESCRIPTION
https://github.com/brianmario/mysql2/issues/532

If the optional exception class is not passed to Timeout, then the mysql connections will not get cleaned up properly.

This should fix some of the "Mysql2::Error: This connection is still waiting for a result" (#72) issues, if they were a result of a job timing out.