### PR TITLE
lock serverengine and thread versions in gemspec

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(/^bin/).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
-  gem.add_dependency 'serverengine'
+  gem.add_dependency 'serverengine', '~> 1.5.5'
   gem.add_dependency 'bunny', '~> 1.7.0'
-  gem.add_dependency 'thread'
+  gem.add_dependency 'thread', '0.1.5'
   gem.add_dependency 'thor'
 
   gem.add_development_dependency 'rr'


### PR DESCRIPTION
Seems necessary considering #112. `thread` doesn't seem to use semantic versioning but `serverengine` does, so it seems safe to set it as is.