### PR TITLE
Give serverengine the same logger object sneakers uses.  Avoid problems ...

### DIFF
--- a/lib/sneakers/runner.rb
+++ b/lib/sneakers/runner.rb
@@ -64,8 +64,15 @@ module Sneakers
     end
 
   private
-    def make_serverengine_config
+  def make_serverengine_config
+      # From Sneakers#setup_general_logger, there's support for a Logger object
+      # in CONFIG[:log].  However, serverengine takes an object in :logger.
+      # Pass our logger object so there's no issue about sometimes passing a
+      # file and sometimes an object.
+      without_log = Sneakers::CONFIG.merge(@conf)
+      without_log.delete(:log)
       Sneakers::CONFIG.merge(@conf).merge({
+        :logger => Sneakers.logger,
         :worker_type => 'process',
         :worker_classes => @worker_classes
       })

--- a/spec/sneakers/runner_spec.rb
+++ b/spec/sneakers/runner_spec.rb
@@ -1,0 +1,26 @@
+require 'logger'
+require 'spec_helper'
+require 'sneakers'
+
+describe Sneakers::Runner do
+  let(:logger) { Logger.new('logtest.log') }
+
+  describe "with configuration that specifies a logger object" do
+    before do
+      Sneakers.configure(log: logger)
+      @runner = Sneakers::Runner.new([])
+    end
+
+    it 'passes the logger to serverengine' do
+      # Stub out ServerEngine::Daemon.run so we only exercise the way we invoke
+      # ServerEngine.create
+      any_instance_of(ServerEngine::Daemon) do |daemon|
+        stub(daemon).main{ return 0 }
+      end
+
+      @runner.run
+      # look at @runner's @se instance variable (actually of type Daemon)...and
+      # figure out what it's logger is...
+    end
+  end
+end


### PR DESCRIPTION
...when Sneakers.configure receives a logger object instead of a log file.

Without this change, I see this stack trace when passing a logger object in :log to Sneakers.configure, and then calling Sneakers::Runner.new.run
```
Unexpected error no implicit conversion of Logging::Logger into String
  /Users/davidbyron/.rbenv/versions/2.2.1/lib/ruby/2.2.0/open-uri.rb:36:in `open'
  /Users/davidbyron/.rbenv/versions/2.2.1/lib/ruby/2.2.0/open-uri.rb:36:in `open'
  /Users/davidbyron/.rbenv/versions/2.2.1/lib/ruby/2.2.0/logger.rb:628:in `open_logfile'
  /Users/davidbyron/.rbenv/versions/2.2.1/lib/ruby/2.2.0/logger.rb:584:in `initialize'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/daemon_logger.rb:64:in `new'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/daemon_logger.rb:64:in `logdev='
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/daemon_logger.rb:47:in `initialize'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/config_loader.rb:66:in `new'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/config_loader.rb:66:in `create_logger'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/daemon.rb:99:in `main'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/serverengine-1.5.10/lib/serverengine/daemon.rb:90:in `run'
  /Users/davidbyron/src/portal_worker/vendor/bundle/gems/sneakers-1.0.3/lib/sneakers/runner.rb:12:in `run'
  /Users/davidbyron/src/portal_worker/lib/portal_runner.rb:17:in `run'
```