### PR TITLE
Fix max retry count for new version of RabbitMQ x-death format

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -171,7 +171,7 @@ module Sneakers
           if x_death_array.count != 1
             x_death_array.count
           else
-            x_death_array.first['count']
+            x_death_array.first['count'] || 1
           end
         end
       end

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -168,10 +168,12 @@ module Sneakers
           x_death_array = headers['x-death'].select do |x_death|
             x_death['queue'] == @worker_queue_name
           end
-          if x_death_array.count != 1
-            x_death_array.count
+          if x_death_array.count > 0 && x_death_array.first['count']
+            # Newer versions of RabbitMQ return headers with a count key
+            x_death_array.inject(0) {|sum, x_death| sum + x_death['count']}
           else
-            x_death_array.first['count'] || 1
+            # Older versions return a separate x-death header for each failure
+            x_death_array.count
           end
         end
       end

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -165,9 +165,14 @@ module Sneakers
         if headers.nil? || headers['x-death'].nil?
           0
         else
-          headers['x-death'].select do |x_death|
+          x_death_array = headers['x-death'].select do |x_death|
             x_death['queue'] == @worker_queue_name
-          end.count
+          end
+          if x_death_array.count != 1
+            x_death_array.count
+          else
+            x_death_array.first['count']
+          end
         end
       end
       private :failure_count


### PR DESCRIPTION
As of March 26, RabbitMQ consolidated the x-death header to have only one entry per queue.  A new "count" value was added to track the number of times it's been in a queue. 

I've adjusted the failure_count method so it should work for both the old and new formats for the x-death header.

https://github.com/rabbitmq/rabbitmq-server/issues/78
https://github.com/rabbitmq/rabbitmq-server/pull/79