### PR TITLE
allow externally-provided Bunny object

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -43,8 +43,8 @@ module Sneakers
       hash = hash.dup
 
       # parse vhost from amqp if vhost is not specified explicitly, only
-      # if we're not given a Bunny object.
-      if hash[:bunny].nil?
+      # if we're not given a connection to use.
+      if hash[:connection].nil?
         if hash[:vhost].nil? && !hash[:amqp].nil?
           hash[:vhost] = AMQ::Settings.parse_amqp_url(hash[:amqp]).fetch(:vhost, '/')
         end

--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -4,7 +4,7 @@ module Sneakers
   class Configuration
 
     extend Forwardable
-    def_delegators :@hash, :to_hash, :[], :[]=, :==, :fetch, :delete
+    def_delegators :@hash, :to_hash, :[], :[]=, :==, :fetch, :delete, :has_key?
 
     DEFAULTS = {
       # runner
@@ -40,10 +40,23 @@ module Sneakers
     end
 
     def merge!(hash)
-      # parse vhost from amqp if vhost is not specified explicitly
-      if hash[:vhost].nil? && !hash[:amqp].nil?
-        hash = hash.dup
-        hash[:vhost] = AMQ::Settings.parse_amqp_url(hash[:amqp]).fetch(:vhost, '/')
+      hash = hash.dup
+
+      # parse vhost from amqp if vhost is not specified explicitly, only
+      # if we're not given a Bunny object.
+      if hash[:bunny].nil?
+        if hash[:vhost].nil? && !hash[:amqp].nil?
+          hash[:vhost] = AMQ::Settings.parse_amqp_url(hash[:amqp]).fetch(:vhost, '/')
+        end
+      else
+        # If we are given a Bunny object, ignore params we'd otherwise use to
+        # create one.  This removes any question about where config params are
+        # coming from, and makes it more likely that downstream code that needs
+        # this info gets it from the right place.
+        [:vhost, :amqp, :heartbeat].each do |k|
+          hash.delete(k)
+          @hash.delete(k)
+        end
       end
 
       @hash.merge!(hash)

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -18,8 +18,8 @@ class Sneakers::Queue
   def subscribe(worker)
     # If we've already got a bunny object, use it.  This allows people to
     # specify all kinds of options we don't need to know about (e.g. for ssl).
-    @bunny = @opts[:bunny]
-    @bunny ||= Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
+    @bunny = @opts[:connection]
+    @bunny ||= create_bunny_connection
     @bunny.start
 
     @channel = @bunny.create_channel
@@ -63,4 +63,9 @@ class Sneakers::Queue
     @consumer.cancel if @consumer
     @consumer = nil
   end
+
+  def create_bunny_connection
+    Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
+  end
+  private :create_bunny_connection
 end

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -16,7 +16,10 @@ class Sneakers::Queue
   # :ack
   #
   def subscribe(worker)
-    @bunny = Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
+    # If we've already got a bunny object, use it.  This allows people to
+    # specify all kinds of options we don't need to know about (e.g. for ssl).
+    @bunny = @opts[:bunny]
+    @bunny ||= Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
     @bunny.start
 
     @channel = @bunny.create_channel

--- a/spec/sneakers/configuration_spec.rb
+++ b/spec/sneakers/configuration_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Sneakers::Configuration do
 
-  describe 'with a Bunny object' do
-    let(:bunny) { Object.new }
+  describe 'with a connection' do
+    let(:connection) { Object.new }
 
     it 'does not use vhost option if it is specified' do
       url = 'amqp://foo:bar@localhost:5672/foobarvhost'
       with_env('RABBITMQ_URL', url) do
         config = Sneakers::Configuration.new
-        config.merge!({ :vhost => 'test_host', :bunny => bunny })
+        config.merge!({ :vhost => 'test_host', :connection => connection })
         config.has_key?(:vhost).must_equal false
       end
     end
@@ -17,12 +17,12 @@ describe Sneakers::Configuration do
     it 'does not amqp option if it is specified' do
       url = 'amqp://foo:bar@localhost:5672'
       config = Sneakers::Configuration.new
-      config.merge!({ :amqp => url, :bunny => bunny })
+      config.merge!({ :amqp => url, :connection => connection })
       config.has_key?(:vhost).must_equal false
     end
   end
 
-  describe 'without a Bunny object' do
+  describe 'without a connection' do
     it 'should assign a default value for :amqp' do
       with_env('RABBITMQ_URL', nil) do
         config = Sneakers::Configuration.new

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -113,12 +113,12 @@ describe Sneakers::Queue do
     end
   end
 
-  describe 'with an externally-provided Bunny object' do
+  describe 'with an externally-provided connection' do
     describe '#subscribe' do
       before do
-        @external_bunny = Bunny.new
-        mock(@external_bunny).start {}
-        mock(@external_bunny).create_channel{ @mkchan }
+        @external_connection = Bunny.new
+        mock(@external_connection).start {}
+        mock(@external_connection).create_channel{ @mkchan }
         mock(@mkchan).exchange("sneakers", :type => :direct, :durable => true){ @mkex }
 
         queue_name = 'foo'
@@ -126,13 +126,13 @@ describe Sneakers::Queue do
         mock(@mkqueue).bind(@mkex, :routing_key => queue_name)
         mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
 
-        my_vars = queue_vars.merge(:bunny => @external_bunny)
+        my_vars = queue_vars.merge(:connection => @external_connection)
         @q = Sneakers::Queue.new(queue_name, my_vars)
       end
 
       it 'uses that object' do
         @q.subscribe(@mkworker)
-        @q.instance_variable_get(:@bunny).must_equal @external_bunny
+        @q.instance_variable_get(:@bunny).must_equal @external_connection
       end
     end
   end


### PR DESCRIPTION
It feels like it oughta be harder than this, but I think this covers it for me.  I'm now calling sneakers like this:
```
    @bunny = Bunny.new('amqp:my_info', logger: Logger.log, heartbeat: Sneakers::Configuration::DEFAULTS[:heartbeat]))
    Sneakers.configure(bunny: @bunny, daemonize: false, log: Logger.log)
```
to get the same info in a Bunny object I used to get when sneakers built it for me.