### PR TITLE
sneakers:run rake task bug and fix for it.

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -26,7 +26,7 @@ Please set the classes of the workers you want to run like so:
 EOF
       exit(1)
     end
-    opts = (ENV['WORKER_COUNT'].present? ? {:workers => ENV['WORKER_COUNT'].to_i} : {})
+    opts = (!ENV['WORKER_COUNT'].nil? ? {:workers => ENV['WORKER_COUNT'].to_i} : {})
     r = Sneakers::Runner.new(workers, opts)
 
     r.run


### PR DESCRIPTION
If I tried to run `WORKERS=DoThings rake sneakers:run`on latest sneakers version on my local machine on Ruby 2.2.2. I got following error:

```
rake aborted!
NoMethodError: undefined method `present?' for nil:NilClass
/Users/otobrglez/.rvm/gems/ruby-2.2.2@hunter/gems/sneakers-1.0.4/lib/sneakers/tasks.rb:29:in `block (2 levels) in <top (required)>'
Tasks: TOP => sneakers:run
(See full trace by running task with --trace)
```

So I decided to hunt down this bug and fix it. This is the patch. Hope it helps. :)