### PR TITLE
Change logger for supervisor

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -65,7 +65,7 @@ module Sneakers
     if [:info, :debug, :error, :warn].all?{ |meth| CONFIG[:log].respond_to?(meth) }
       @logger = CONFIG[:log]
     else
-      @logger = Logger.new(CONFIG[:log])
+      @logger = ServerEngine::DaemonLogger.new(CONFIG[:log])
       @logger.formatter = Sneakers::Support::ProductionFormatter
     end
   end

--- a/lib/sneakers/runner.rb
+++ b/lib/sneakers/runner.rb
@@ -63,19 +63,22 @@ module Sneakers
       config
     end
 
-  private
-  def make_serverengine_config
+    private
+
+    def make_serverengine_config
       # From Sneakers#setup_general_logger, there's support for a Logger object
       # in CONFIG[:log].  However, serverengine takes an object in :logger.
       # Pass our logger object so there's no issue about sometimes passing a
       # file and sometimes an object.
-      without_log = Sneakers::CONFIG.merge(@conf)
-      without_log.delete(:log)
-      Sneakers::CONFIG.merge(@conf).merge({
+      serverengine_config =  Sneakers::CONFIG.merge(@conf)
+      serverengine_config.merge!(
         :logger => Sneakers.logger,
         :worker_type => 'process',
         :worker_classes => @worker_classes
-      })
+      )
+      serverengine_config.delete(:log)
+
+      serverengine_config
     end
   end
 

--- a/spec/sneakers/runner_spec.rb
+++ b/spec/sneakers/runner_spec.rb
@@ -24,3 +24,21 @@ describe Sneakers::Runner do
     end
   end
 end
+
+describe Sneakers::RunnerConfig do
+  let(:logger) { Logger.new("logtest.log") }
+  let(:runner_config) { Sneakers::Runner.new([]).instance_variable_get("@runnerconfig") }
+
+  before { Sneakers.configure(log: logger) }
+
+
+  describe "#reload_config!" do
+    it "must not have :log key" do
+      runner_config.reload_config!.has_key?(:log).must_equal false
+    end
+
+    it "must have :logger key as an instance of Logger" do
+      runner_config.reload_config![:logger].is_a?(Logger).must_equal true
+    end
+  end
+end

--- a/spec/sneakers/sneakers_spec.rb
+++ b/spec/sneakers/sneakers_spec.rb
@@ -54,14 +54,16 @@ describe Sneakers do
 
 
   describe '#setup_general_logger' do
+    let(:logger_class) { ServerEngine::DaemonLogger }
+
     it 'should detect a string and configure a logger' do
       Sneakers.configure(:log => 'sneakers.log')
-      Sneakers.logger.kind_of?(Logger).must_equal(true)
+      Sneakers.logger.kind_of?(logger_class).must_equal(true)
     end
 
     it 'should detect a file-like thing and configure a logger' do
       Sneakers.configure(:log => STDOUT)
-      Sneakers.logger.kind_of?(Logger).must_equal(true)
+      Sneakers.logger.kind_of?(logger_class).must_equal(true)
     end
 
     it 'should detect an actual logger and configure it' do


### PR DESCRIPTION
Hi, I found problems using with ServerEngine supervisor.

Current Sneakers gives logger to ServerEngine.
This behavior was added by https://github.com/jondot/sneakers/commit/f90e810f5cdc30aaf38fe8f4d39afa3339380b81 .
But in this commit, Sneakers give both :log and :logger options to ServerEngine.

Firstly, I fixed to give only :logger option to ServerEngine.

And when ServerEngine is received a Logger instance as :logger option, ServerEngine aborts.
For detail, Please see https://github.com/fluent/serverengine/pull/20 .

Secondly, I make Sneakers use ServerEngine::DaemonLogger as logger.