### PR TITLE
Allow setting logger and provide server configuration convenience block

### DIFF
--- a/bin/sneakers
+++ b/bin/sneakers
@@ -2,4 +2,5 @@
 require 'sneakers'
 require 'sneakers/cli'
 
+Sneakers.server = true
 Sneakers::CLI.start

--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -47,6 +47,10 @@ module Sneakers
     logger.level = loglevel
   end
 
+  def logger=(logger)
+    @logger = logger
+  end
+
   def logger
     @logger
   end
@@ -57,6 +61,18 @@ module Sneakers
 
   def configured?
     @configured
+  end
+
+  def server=(server)
+    @server = server
+  end
+
+  def server?
+    @server
+  end
+
+  def configure_server
+    yield self if server?
   end
 
   private

--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -5,7 +5,9 @@ task :environment
 
 namespace :sneakers do
   desc "Start work (set $WORKERS=Klass1,Klass2)"
-  task :run  => :environment do
+  task :run do
+    Sneakers.server = true
+    Rake::Task['environment'].invoke
 
     workers, missing_workers = Sneakers::Utils.parse_workers(ENV['WORKERS'])
 


### PR DESCRIPTION
Hi @jondot

People that run Rails often want to set configuration of their workers in initializers.  This configuration should only be active for workers processes and not the when running a normal rails server web process.  Consider what sidekiq provides:

```Ruby
# This block will only yield for sidekiq worker processes.
Sidekiq.configure_server do |config|
  # Place standard Rails output produced when running a job in the worker log file.
  Rails.logger = Sidekiq::Logging.logger
  # Do other config such as adjust DB connection pools, etc. etc.
end
```

This pull request adds two features:
1) A way to override the sneakers logger.
2) A configure_server block method that only yields when running a worker.  Implemented in a common way similar to other gems.

Regards
Pierre