### PR TITLE
Add arguments parameter to exchange

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -25,6 +25,7 @@ module Sneakers
       :heartbeat          => 2,
       :exchange           => 'sneakers',
       :exchange_type      => :direct,
+      :exchange_arguments => {}, # Passed as :arguments to Bunny::Channel#exchange
       :hooks              => {}
     }.freeze
 

--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -23,7 +23,7 @@ module Sneakers
       @bunny = Bunny.new(@opts[:amqp], heartbeat: @opts[:heartbeat], vhost: @opts[:vhost], :logger => Sneakers::logger)
       @bunny.start
       @channel = @bunny.create_channel
-      @exchange = @channel.exchange(@opts[:exchange], type: @opts[:exchange_type], durable: @opts[:durable])
+      @exchange = @channel.exchange(@opts[:exchange], type: @opts[:exchange_type], durable: @opts[:durable], arguments: @opts[:exchange_arguments])
     end
 
     def connected?

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -28,7 +28,8 @@ class Sneakers::Queue
     exchange_name = @opts[:exchange]
     @exchange = @channel.exchange(exchange_name,
                                   :type => @opts[:exchange_type],
-                                  :durable => @opts[:durable])
+                                  :durable => @opts[:durable],
+                                  :arguments => @opts[:exchange_arguments])
 
     routing_key = @opts[:routing_key] || @name
     routing_keys = [*routing_key]

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -60,11 +60,12 @@ describe Sneakers::Publisher do
         amqp: 'amqp://someuser:somepassword@somehost:5672',
         heartbeat: 1, exchange: 'another_exchange',
         exchange_type: :topic,
+        exchange_arguments: { 'x-arg' => 'value' },
         log: logger,
         durable: false)
 
       channel = Object.new
-      mock(channel).exchange('another_exchange', type: :topic, durable: false) do
+      mock(channel).exchange('another_exchange', type: :topic, durable: false, arguments: { 'x-arg' => 'value' }) do
         mock(Object.new).publish('test msg', routing_key: 'downloads')
       end
 

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -10,7 +10,8 @@ describe Sneakers::Queue do
       :heartbeat => 2,
       :vhost => '/',
       :exchange => "sneakers",
-      :exchange_type => :direct
+      :exchange_type => :direct,
+      :exchange_arguments => { 'x-arg' => 'value' }
     }
   end
 
@@ -37,7 +38,10 @@ describe Sneakers::Queue do
 
     describe "#subscribe with sneakers exchange" do
       before do
-        mock(@mkchan).exchange("sneakers", :type => :direct, :durable => true){ @mkex }
+        mock(@mkchan).exchange("sneakers",
+                               :type => :direct,
+                               :durable => true,
+                               :arguments => { 'x-arg' => 'value' }){ @mkex }
       end
 
       it "should setup a bunny queue according to configuration values" do
@@ -119,7 +123,10 @@ describe Sneakers::Queue do
         @external_connection = Bunny.new
         mock(@external_connection).start {}
         mock(@external_connection).create_channel{ @mkchan }
-        mock(@mkchan).exchange("sneakers", :type => :direct, :durable => true){ @mkex }
+        mock(@mkchan).exchange("sneakers",
+                               :type => :direct,
+                               :durable => true,
+                               :arguments => { 'x-arg' => 'value' }){ @mkex }
 
         queue_name = 'foo'
         mock(@mkchan).queue(queue_name, :durable => true) { @mkqueue }

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -177,6 +177,7 @@ describe Sneakers::Worker do
           :vhost => "/",
           :exchange => "sneakers",
           :exchange_type => :direct,
+          :exchange_arguments => {},
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat  =>  2
@@ -202,6 +203,7 @@ describe Sneakers::Worker do
           :vhost => "/",
           :exchange => "dummy",
           :exchange_type => :direct,
+          :exchange_arguments => {},
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 5


### PR DESCRIPTION
In order to use [custom attributes on an exchange](http://www.rubydoc.info/gems/bunny/Bunny%2FChannel%3Aexchange), I added the option `exchange_arguments` to the configuration. Our use case is the [Delayed Message Plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange).

Thanks