### PR TITLE
Bump dependent gem bunny version to enable mri timeout fixes

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine', '~> 1.5.5'
-  gem.add_dependency 'bunny', '~> 1.7.0'
+  gem.add_dependency 'bunny', ['>= 1.7.0', '<= 2.0.0']
   gem.add_dependency 'thread', '~> 0.1.7'
   gem.add_dependency 'thor'
 


### PR DESCRIPTION
Allow the new features and bug fixes in the new bunny release  http://blog.rubyrabbitmq.info/blog/2015/06/14/bunny-2-dot-0-0-rc1-is-released/ . Specially the ruby Timeout class fix (new “interruptor” thread per operation)
Thanks
ping @jondot 