### PR TITLE
use `from_queue` options in `Worker.enqueue`

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -143,7 +143,7 @@ module Sneakers
       private
 
       def publisher
-        @publisher ||= Sneakers::Publisher.new
+        @publisher ||= Sneakers::Publisher.new(queue_opts)
       end
     end
   end

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -145,9 +145,12 @@ describe Sneakers::Worker do
         msg.must_equal(message)
         opts.must_equal(:to_queue => "defaults")
       end
+    end
 
-      stub(Sneakers::Publisher).new { mock }
-      DefaultsWorker.enqueue(message)
+    it "passes the configuration to the publisher" do
+      opts = DummyWorker.queue_opts
+      mock(Sneakers::Publisher).new(opts) { mock(Object.new).publish(anything, anything) }
+      DummyWorker.enqueue(message)
     end
   end
 


### PR DESCRIPTION
Given the following worker:

```ruby
class MyWorker
  include Sneakers::Worker
  from_queue 'swag', exchange: 'other'
end
```

`MyWorker.enqueue 'yolo'` would now publish the message to `sneakers` (the default) exchange. The worker will never pick it up.

This patch fixes this behaviour. Calling `MyWorker.enqueue 'yolo'` will publish a message to an exchange called `other`.