### PR TITLE
Redact password from inspection of the config object. Resolves #28

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -71,5 +71,16 @@ module Sneakers
       instance.merge! hash
       instance
     end
+
+    def inspect_with_redaction
+      redacted = self.class.new
+      redacted.merge! to_hash
+
+      # redact passwords
+      redacted[:amqp] = redacted[:amqp].sub(/(?<=\Aamqp:\/)[^@]+(?=@)/, "<redacted>")
+      return redacted.inspect_without_redaction
+    end
+    alias_method :inspect_without_redaction, :inspect
+    alias_method :inspect, :inspect_with_redaction
   end
 end


### PR DESCRIPTION
This is easier than trying to filter it whenever it is logged, although may not be the cleanest solution.