### PR TITLE
Add a thingy to deserialize JSON

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -17,6 +17,7 @@ require 'sneakers/concerns/metrics'
 require 'sneakers/handlers/oneshot'
 require 'sneakers/worker'
 require 'sneakers/publisher'
+require 'sneakers/deserializer'
 
 module Sneakers
   extend self

--- a/lib/sneakers/deserializer.rb
+++ b/lib/sneakers/deserializer.rb
@@ -1,0 +1,1 @@
+require 'sneakers/deserializer/json'

--- a/lib/sneakers/deserializer/json.rb
+++ b/lib/sneakers/deserializer/json.rb
@@ -1,0 +1,13 @@
+module Sneakers
+  module Deserializer
+    module JSON
+      def self.included(receiver)
+        _do_work = receiver.instance_method(:do_work)
+        receiver.send(:define_method, :do_work) do |delivery_info, metadata, msg, handler|
+          msg = ::JSON.parse(msg) if metadata[:content_type] == 'application/json'
+          _do_work.bind(self).(delivery_info, metadata, msg,handler)
+        end
+      end
+    end
+  end
+end

--- a/spec/sneakers/json_deserializer_spec.rb
+++ b/spec/sneakers/json_deserializer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'sneakers'
+
+class JSONDummyWorker
+  include Sneakers::Worker
+  include Sneakers::Deserializer::JSON
+  from_queue 'downloads',
+             :durable => false,
+             :ack => false,
+             :threads => 50,
+             :prefetch => 40,
+             :timeout_job_after => 1,
+             :exchange => 'dummy',
+             :heartbeat => 5
+
+  def work(msg)
+  end
+end
+
+class TestPool
+  def process(*args,&block)
+    block.call
+  end
+end
+
+describe Sneakers::Deserializer::JSON do
+  before do
+    @queue = Object.new
+    @exchange = Object.new
+    stub(@queue).name { 'test-queue' }
+    stub(@queue).opts { {} }
+    stub(@queue).exchange { @exchange }
+
+    Sneakers.clear!
+    Sneakers.configure(:daemonize => true, :log => 'sneakers.log')
+    Sneakers::Worker.configure_metrics
+  end
+
+  describe "#do_work" do
+    it "should deserialise json" do
+      w = JSONDummyWorker.new(@queue, TestPool.new)
+      mock(w).work({"foo" => "bar"}).once
+      w.do_work(nil, { content_type: 'application/json' }, '{"foo":"bar"}', nil)
+    end
+
+    it "should not deserialise json if the content type is not present" do
+      w = JSONDummyWorker.new(@queue, TestPool.new)
+      mock(w).work('{"foo":"bar"').once
+      w.do_work(nil, {}, '{"foo":"bar"', nil)
+    end
+  end
+end


### PR DESCRIPTION
I was having a look at https://github.com/jondot/sneakers/issues/126 and came up with this as an idea for a patten to implement deserializers. I am just putting this forward really as a discussion point rather than something I expect to be merged in straight away.

* Is this something that should be added like this with an `include` in each worker?  Or would it perhaps be better to be switched on with an option in the config?
* The meta-programming for this is horrible, and it would be much better to do a little refactoring in the worker to expose some hooks for this.