### PR TITLE
Content type (de)serialization

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -17,6 +17,7 @@ require 'sneakers/support/production_formatter'
 require 'sneakers/concerns/logging'
 require 'sneakers/concerns/metrics'
 require 'sneakers/handlers/oneshot'
+require 'sneakers/content_type'
 require 'sneakers/worker'
 require 'sneakers/publisher'
 

--- a/lib/sneakers/content_type.rb
+++ b/lib/sneakers/content_type.rb
@@ -1,14 +1,22 @@
 module Sneakers
   class ContentType
     def self.register(content_type: nil, serializer: nil, deserializer: nil)
+      @_active = true
       @_types[content_type] = new(serializer, deserializer)
     end
 
-    def self.[](content_type)
-      @_types[content_type]
+    def self.serialize(payload, content_type)
+      return payload unless @_active
+      @_types[content_type].serialize(payload)
+    end
+
+    def self.deserialize(payload, content_type)
+      return payload unless @_active
+      @_types[content_type].deserialize(payload)
     end
 
     def self.reset!
+      @_active = false
       @_types = Hash.new(
         new(->(payload) { payload }, ->(payload) { payload })
       )

--- a/lib/sneakers/content_type.rb
+++ b/lib/sneakers/content_type.rb
@@ -1,6 +1,7 @@
 module Sneakers
   class ContentType
     def self.register(content_type: nil, serializer: nil, deserializer: nil)
+      fail ArgumentError, 'missing keyword: content_type' unless content_type
       @_types[content_type] = new(serializer, deserializer)
     end
 

--- a/lib/sneakers/content_type.rb
+++ b/lib/sneakers/content_type.rb
@@ -1,7 +1,17 @@
 module Sneakers
   class ContentType
     def self.register(content_type: nil, serializer: nil, deserializer: nil)
-      fail ArgumentError, 'missing keyword: content_type' unless content_type
+      # This can be removed when support is dropped for ruby 2.0 and replaced
+      # by a keyword arg with no default value
+      fail ArgumentError, 'missing keyword: content_type' if content_type.nil?
+      fail ArgumentError, 'missing keyword: serializer' if serializer.nil?
+      fail ArgumentError, 'missing keyword: deserializer' if deserializer.nil?
+
+      fail ArgumentError, "#{content_type} serializer must be a proc" unless serializer.is_a? Proc
+      fail ArgumentError, "#{content_type} deserializer must be a proc" unless deserializer.is_a? Proc
+
+      fail ArgumentError, "#{content_type} serializer must accept one argument, the payload" unless serializer.arity == 1
+      fail ArgumentError, "#{content_type} deserializer must accept one argument, the payload" unless deserializer.arity == 1
       @_types[content_type] = new(serializer, deserializer)
     end
 

--- a/lib/sneakers/content_type.rb
+++ b/lib/sneakers/content_type.rb
@@ -1,0 +1,32 @@
+module Sneakers
+  class ContentType
+    def self.register(content_type: nil, serializer: nil, deserializer: nil)
+      @_types[content_type] = new(serializer, deserializer)
+    end
+
+    def self.[](content_type)
+      @_types[content_type]
+    end
+
+    def self.reset!
+      @_types = Hash.new(
+        new(->(payload) { payload }, ->(payload) { payload })
+      )
+    end
+
+    def initialize(serializer, deserializer)
+      @serializer = serializer
+      @deserializer = deserializer
+    end
+
+    def serialize(payload)
+      @serializer.(payload)
+    end
+
+    def deserialize(payload)
+      @deserializer.(payload)
+    end
+
+    reset!
+  end
+end

--- a/lib/sneakers/content_type.rb
+++ b/lib/sneakers/content_type.rb
@@ -5,10 +5,12 @@ module Sneakers
     end
 
     def self.serialize(payload, content_type)
+      return payload unless content_type
       @_types[content_type].serializer.(payload)
     end
 
     def self.deserialize(payload, content_type)
+      return payload unless content_type
       @_types[content_type].deserializer.(payload)
     end
 

--- a/lib/sneakers/content_type.rb
+++ b/lib/sneakers/content_type.rb
@@ -1,25 +1,25 @@
 module Sneakers
   class ContentType
     def self.register(content_type: nil, serializer: nil, deserializer: nil)
-      @_active = true
       @_types[content_type] = new(serializer, deserializer)
     end
 
     def self.serialize(payload, content_type)
-      return payload unless @_active
-      @_types[content_type].serialize(payload)
+      @_types[content_type].serializer.(payload)
     end
 
     def self.deserialize(payload, content_type)
-      return payload unless @_active
-      @_types[content_type].deserialize(payload)
+      @_types[content_type].deserializer.(payload)
     end
 
     def self.reset!
-      @_active = false
       @_types = Hash.new(
-        new(->(payload) { payload }, ->(payload) { payload })
+        new(passthrough, passthrough)
       )
+    end
+
+    def self.passthrough
+      ->(payload) { payload }
     end
 
     def initialize(serializer, deserializer)
@@ -27,13 +27,7 @@ module Sneakers
       @deserializer = deserializer
     end
 
-    def serialize(payload)
-      @serializer.(payload)
-    end
-
-    def deserialize(payload)
-      @deserializer.(payload)
-    end
+    attr_reader :serializer, :deserializer
 
     reset!
   end

--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -12,7 +12,7 @@ module Sneakers
       to_queue = options.delete(:to_queue)
       options[:routing_key] ||= to_queue
       Sneakers.logger.info {"publishing <#{msg}> to [#{options[:routing_key]}]"}
-      @exchange.publish(ContentType[options[:content_type]].serialize(msg), options)
+      @exchange.publish(ContentType.serialize(msg, options[:content_type]), options)
     end
 
 

--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -12,7 +12,7 @@ module Sneakers
       to_queue = options.delete(:to_queue)
       options[:routing_key] ||= to_queue
       Sneakers.logger.info {"publishing <#{msg}> to [#{options[:routing_key]}]"}
-      @exchange.publish(msg, options)
+      @exchange.publish(ContentType[options[:content_type]].serialize(msg), options)
     end
 
 

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -21,6 +21,7 @@ module Sneakers
       @timeout_after = opts[:timeout_job_after]
       @pool = pool || Thread.pool(opts[:threads]) # XXX config threads
       @call_with_params = respond_to?(:work_with_params)
+      @content_type = opts[:content_type]
 
       @queue = queue || Sneakers::Queue.new(
         queue_name,
@@ -39,7 +40,7 @@ module Sneakers
       to_queue = opts.delete(:to_queue)
       opts[:routing_key] ||= to_queue
       return unless opts[:routing_key]
-      @queue.exchange.publish(msg, opts)
+      @queue.exchange.publish(Sneakers::ContentType[opts[:content_type]].serialize(msg), opts)
     end
 
     def do_work(delivery_info, metadata, msg, handler)
@@ -53,10 +54,11 @@ module Sneakers
           metrics.increment("work.#{self.class.name}.started")
           Timeout.timeout(@timeout_after, WorkerTimeout) do
             metrics.timing("work.#{self.class.name}.time") do
+              deserialized_msg = ContentType[@content_type || metadata && metadata[:content_type]].deserialize(msg)
               if @call_with_params
-                res = work_with_params(msg, delivery_info, metadata)
+                res = work_with_params(deserialized_msg, delivery_info, metadata)
               else
-                res = work(msg)
+                res = work(deserialized_msg)
               end
             end
           end
@@ -133,6 +135,7 @@ module Sneakers
 
       def enqueue(msg, opts={})
         opts[:routing_key] ||= @queue_opts[:routing_key]
+        opts[:content_type] ||= @queue_opts[:content_type]
         opts[:to_queue] ||= @queue_name
 
         publisher.publish(msg, opts)

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -40,7 +40,7 @@ module Sneakers
       to_queue = opts.delete(:to_queue)
       opts[:routing_key] ||= to_queue
       return unless opts[:routing_key]
-      @queue.exchange.publish(Sneakers::ContentType[opts[:content_type]].serialize(msg), opts)
+      @queue.exchange.publish(Sneakers::ContentType.serialize(msg, opts[:content_type]), opts)
     end
 
     def do_work(delivery_info, metadata, msg, handler)
@@ -54,7 +54,7 @@ module Sneakers
           metrics.increment("work.#{self.class.name}.started")
           Timeout.timeout(@timeout_after, WorkerTimeout) do
             metrics.timing("work.#{self.class.name}.time") do
-              deserialized_msg = ContentType[@content_type || metadata && metadata[:content_type]].deserialize(msg)
+              deserialized_msg = ContentType.deserialize(msg, @content_type || metadata && metadata[:content_type])
               if @call_with_params
                 res = work_with_params(deserialized_msg, delivery_info, metadata)
               else

--- a/spec/sneakers/content_type_spec.rb
+++ b/spec/sneakers/content_type_spec.rb
@@ -56,5 +56,9 @@ describe Sneakers::ContentType do
       ct = Sneakers::ContentType
       ct.deserialize(ct.serialize('hello world', 'text/base64'), 'text/base64').must_equal('hello world')
     end
+
+    it 'requires a content type' do
+      proc { Sneakers::ContentType.register }.must_raise ArgumentError
+    end
   end
 end

--- a/spec/sneakers/content_type_spec.rb
+++ b/spec/sneakers/content_type_spec.rb
@@ -29,11 +29,19 @@ describe Sneakers::ContentType do
     end
   end
 
-  describe '.[]' do
-    it 'returns a pass through (de)serializer by default' do
+  describe '.serialize' do
+    it 'returns a pass through by default' do
       payload = "just some text"
-      Sneakers::ContentType['unknown/type'].serialize(payload).must_equal(payload)
-      Sneakers::ContentType['unknown/type'].deserialize(payload).must_equal(payload)
+      Sneakers::ContentType.serialize(payload, 'unknown/type').must_equal(payload)
+      Sneakers::ContentType.deserialize(payload, 'unknown/type').must_equal(payload)
+    end
+
+    it 'returns a pass through if not found type' do
+      Sneakers::ContentType.register(content_type: 'found/type')
+      payload = "just some text"
+
+      Sneakers::ContentType.serialize(payload, 'unknown/type').must_equal(payload)
+      Sneakers::ContentType.deserialize(payload, 'unknown/type').must_equal(payload)
     end
   end
 
@@ -45,8 +53,8 @@ describe Sneakers::ContentType do
         deserializer: ->(payload) { Base64.decode64(payload) },
       )
 
-      mime = Sneakers::ContentType['text/base64']
-      mime.deserialize(mime.serialize('hello world')).must_equal('hello world')
+      ct = Sneakers::ContentType
+      ct.deserialize(ct.serialize('hello world', 'text/base64'), 'text/base64').must_equal('hello world')
     end
   end
 end

--- a/spec/sneakers/content_type_spec.rb
+++ b/spec/sneakers/content_type_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'sneakers/content_type'
+require 'base64'
+
+describe Sneakers::ContentType do
+  after do
+    Sneakers::ContentType.reset!
+  end
+
+  describe '#serialize' do
+    it 'uses the given serializer' do
+      json = Sneakers::ContentType.new(
+        ->(payload) { JSON.dump(payload) },
+        nil,
+      )
+
+      json.serialize('foo' => 'bar').must_equal('{"foo":"bar"}')
+    end
+  end
+
+  describe '#deserialize' do
+    it 'uses the given deserializer' do
+      json = Sneakers::ContentType.new(
+        nil,
+        ->(payload) { JSON.parse(payload) },
+      )
+
+      json.deserialize('{"foo":"bar"}').must_equal('foo' => 'bar')
+    end
+  end
+
+  describe '.[]' do
+    it 'returns a pass through (de)serializer by default' do
+      payload = "just some text"
+      Sneakers::ContentType['unknown/type'].serialize(payload).must_equal(payload)
+      Sneakers::ContentType['unknown/type'].deserialize(payload).must_equal(payload)
+    end
+  end
+
+  describe '.register' do
+    it 'provides a mechnism to register a given type' do
+      Sneakers::ContentType.register(
+        content_type: 'text/base64',
+        serializer: ->(payload) { Base64.encode64(payload) },
+        deserializer: ->(payload) { Base64.decode64(payload) },
+      )
+
+      mime = Sneakers::ContentType['text/base64']
+      mime.deserialize(mime.serialize('hello world')).must_equal('hello world')
+    end
+  end
+end

--- a/spec/sneakers/content_type_spec.rb
+++ b/spec/sneakers/content_type_spec.rb
@@ -7,36 +7,36 @@ describe Sneakers::ContentType do
     Sneakers::ContentType.reset!
   end
 
-  describe '#serialize' do
-    it 'uses the given serializer' do
-      json = Sneakers::ContentType.new(
-        ->(payload) { JSON.dump(payload) },
-        nil,
-      )
-
-      json.serialize('foo' => 'bar').must_equal('{"foo":"bar"}')
-    end
-  end
-
-  describe '#deserialize' do
+  describe '.deserialize' do
     it 'uses the given deserializer' do
-      json = Sneakers::ContentType.new(
-        nil,
-        ->(payload) { JSON.parse(payload) },
+      Sneakers::ContentType.register(
+        content_type: 'application/json',
+        deserializer: ->(payload) { JSON.parse(payload) },
       )
 
-      json.deserialize('{"foo":"bar"}').must_equal('foo' => 'bar')
+      Sneakers::ContentType.deserialize('{"foo":"bar"}', 'application/json').must_equal('foo' => 'bar')
     end
   end
 
   describe '.serialize' do
-    it 'returns a pass through by default' do
+     it 'uses the given serializer' do
+      Sneakers::ContentType.register(
+        content_type: 'application/json',
+        serializer: ->(payload) { JSON.dump(payload) },
+      )
+
+      Sneakers::ContentType.serialize({ 'foo' => 'bar' }, 'application/json').must_equal('{"foo":"bar"}')
+    end
+
+    it 'passes the payload through by default' do
       payload = "just some text"
       Sneakers::ContentType.serialize(payload, 'unknown/type').must_equal(payload)
       Sneakers::ContentType.deserialize(payload, 'unknown/type').must_equal(payload)
+      Sneakers::ContentType.serialize(payload, nil).must_equal(payload)
+      Sneakers::ContentType.deserialize(payload, nil).must_equal(payload)
     end
 
-    it 'returns a pass through if not found type' do
+    it 'passes the payload through if type not found' do
       Sneakers::ContentType.register(content_type: 'found/type')
       payload = "just some text"
 

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sneakers'
+require 'serverengine'
 
 describe Sneakers::Publisher do
   let :pub_vars do
@@ -121,6 +122,24 @@ describe Sneakers::Publisher do
       p = Sneakers::Publisher.new
       p.publish('test msg', my_vars)
       p.instance_variable_get(:@bunny).must_equal existing_session
+    end
+
+    it 'should publish using the content type serializer' do
+      Sneakers::ContentType.register(
+        content_type: 'application/json',
+        serializer: ->(payload) { JSON.dump(payload) },
+      )
+
+      xchg = Object.new
+      mock(xchg).publish('{"foo":"bar"}', routing_key: 'downloads', content_type: 'application/json')
+
+      p = Sneakers::Publisher.new
+      p.instance_variable_set(:@exchange, xchg)
+
+      mock(p).ensure_connection! {}
+      p.publish({ 'foo' => 'bar' }, to_queue: 'downloads', content_type: 'application/json')
+
+      Sneakers::ContentType.reset!
     end
   end
 end

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -128,6 +128,7 @@ describe Sneakers::Publisher do
       Sneakers::ContentType.register(
         content_type: 'application/json',
         serializer: ->(payload) { JSON.dump(payload) },
+        deserializer: ->(_) {},
       )
 
       xchg = Object.new

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -357,6 +357,7 @@ describe Sneakers::Worker do
       before do
         Sneakers::ContentType.register(
           content_type: 'application/json',
+          serializer: ->(_) {},
           deserializer: ->(payload) { JSON.parse(payload) },
         )
       end
@@ -492,6 +493,7 @@ describe Sneakers::Worker do
         Sneakers::ContentType.register(
           content_type: 'application/json',
           serializer: ->(payload) { JSON.dump(payload) },
+          deserializer: ->(_) {},
         )
       end
 


### PR DESCRIPTION
Ok so this is my second bash at one of the ideas mooted in https://github.com/jondot/sneakers/issues/126.

This allows ContentTypes to be configured like so:

``` ruby
Sneakers::ContentType.register(
  content_type: 'application/json',
  deserializer: ->(payload) { JSON.parse(payload) },
  serializer: ->(payload) { JSON.dump(payload) },
)
```

Then when messages arrive with the given content type metadata set the payload should be deserialized neatly.

Its also possible to add `content_type: 'whatever/thing'` to the worker options, in order that every message will be deserialized using the given type, irrespective of what the message metadata purports.

The publishing methods now also use the serializers when `content_type` is present in the options.

If nothing is registered everything just falls back to a noop pair of (de)serializers that just pass through the message unchanged, so this shouldn't break anyones existing applications.
