### PR TITLE
Fix missing `require` that prevented Rails to start

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -2,6 +2,7 @@ require "sneakers/version"
 require 'thread/pool'
 require 'bunny'
 require 'logger'
+require 'serverengine'
 
 module Sneakers
   module Handlers


### PR DESCRIPTION
Without this modification, Rails console was crashing during start:
```
→ bundle exec rails c
Connecting to database specified by database.yml
/home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/sneakers-1.1.1/lib/sneakers.rb:84:in `setup_general_logger!': uninitialized constant Sneakers::ServerEngine (NameError)
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/sneakers-1.1.1/lib/sneakers.rb:30:in `configure'
	from /home/mike/code/kyero/kyero/config/initializers/sneakers.rb:3:in `<top (required)>'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/engine.rb:593:in `block (2 levels) in <class:Engine>'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/engine.rb:592:in `each'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/engine.rb:592:in `block in <class:Engine>'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/initializable.rb:30:in `instance_exec'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/initializable.rb:30:in `run'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/initializable.rb:54:in `each'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/initializable.rb:54:in `run_initializers'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/application.rb:136:in `initialize!'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/railtie/configurable.rb:30:in `method_missing'
	from /home/mike/code/kyero/kyero/config/environment.rb:5:in `<top (required)>'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/application.rb:103:in `require_environment!'
	from /home/mike/.rvm/gems/ruby-2.0.0-p598@kyero/gems/railties-3.2.19/lib/rails/commands.rb:40:in `<top (required)>'
	from script/rails:6:in `require'
	from script/rails:6:in `<main>'
```
Not sure why, but it works with this :smile: 