### PR TITLE
Fix "log writing failed" error for umlauts

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -42,7 +42,7 @@ module Sneakers
     end
 
     def do_work(delivery_info, metadata, msg, handler)
-      worker_trace "Working off: #{msg}"
+      worker_trace "Working off: #{msg.inspect}"
 
       @pool.process do
         res = nil


### PR DESCRIPTION
When the message contains an umlaut, such as "ä", the logging fails with this error:
`log writing failed. "\xC3" from ASCII-8BIT to UTF-8`

Using `String#inspect` the string gets the proper encoding to write it to the log.