### PR TITLE
allow Sneakers::Publisher to use externally instantiated Bunny::Session

### DIFF
--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -20,7 +20,10 @@ module Sneakers
 
   private
     def ensure_connection!
-      @bunny = Bunny.new(@opts[:amqp], heartbeat: @opts[:heartbeat], vhost: @opts[:vhost], :logger => Sneakers::logger)
+      # If we've already got a bunny object, use it.  This allows people to
+      # specify all kinds of options we don't need to know about (e.g. for ssl).
+      @bunny = @opts[:connection]
+      @bunny ||= create_bunny_connection
       @bunny.start
       @channel = @bunny.create_channel
       @exchange = @channel.exchange(@opts[:exchange], type: @opts[:exchange_type], durable: @opts[:durable], arguments: @opts[:exchange_arguments])
@@ -28,6 +31,10 @@ module Sneakers
 
     def connected?
       @bunny && @bunny.connected?
+    end
+
+    def create_bunny_connection
+      Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
     end
   end
 end

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -2,6 +2,19 @@ require 'spec_helper'
 require 'sneakers'
 
 describe Sneakers::Publisher do
+  let :pub_vars do
+    {
+      :prefetch => 25,
+      :durable => true,
+      :ack => true,
+      :heartbeat => 2,
+      :vhost => '/',
+      :exchange => "sneakers",
+      :exchange_type => :direct,
+      :exchange_arguments => { 'x-arg' => 'value' }
+    }
+  end
+
   describe '#publish' do
     before do
       Sneakers.clear!
@@ -78,7 +91,36 @@ describe Sneakers::Publisher do
       p = Sneakers::Publisher.new
 
       p.publish('test msg', to_queue: 'downloads')
+    end
 
+    it 'should use an externally instantiated bunny session if provided' do
+      logger = Logger.new('/dev/null')
+      channel = Object.new
+      exchange = Object.new
+      existing_session = Bunny.new
+      my_vars = pub_vars.merge(to_queue: 'downloads')
+
+      mock(existing_session).start
+      mock(existing_session).create_channel { channel }
+
+      mock(channel).exchange('another_exchange', type: :topic, durable: false, arguments: { 'x-arg' => 'value' }) do
+        exchange
+      end
+
+      mock(exchange).publish('test msg', my_vars)
+
+      Sneakers.configure(
+        connection: existing_session,
+        heartbeat: 1, exchange: 'another_exchange',
+        exchange_type: :topic,
+        exchange_arguments: { 'x-arg' => 'value' },
+        log: logger,
+        durable: false
+      )
+
+      p = Sneakers::Publisher.new
+      p.publish('test msg', my_vars)
+      p.instance_variable_get(:@bunny).must_equal existing_session
     end
   end
 end


### PR DESCRIPTION
`Sneakers::Publisher` should support using the `:connection` option.