### PR TITLE
Maxretry: use queue durability setting from new name opts[:queue_options][:durable]

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -52,7 +52,7 @@ module Sneakers
           Sneakers.logger.debug { "#{log_prefix} creating exchange=#{name}" }
           @channel.exchange(name,
                             :type => 'topic',
-                            :durable => opts[:durable])
+                            :durable => exchange_durable?)
         end
 
         # Create the queues and bindings
@@ -60,7 +60,7 @@ module Sneakers
           "#{log_prefix} creating queue=#{retry_name} x-dead-letter-exchange=#{requeue_name}"
         end
         @retry_queue = @channel.queue(retry_name,
-                                     :durable => opts[:durable],
+                                     :durable => queue_durable?,
                                      :arguments => {
                                        :'x-dead-letter-exchange' => requeue_name,
                                        :'x-message-ttl' => @opts[:retry_timeout] || 60000
@@ -71,7 +71,7 @@ module Sneakers
           "#{log_prefix} creating queue=#{error_name}"
         end
         @error_queue = @channel.queue(error_name,
-                                      :durable => opts[:durable])
+                                      :durable => queue_durable?)
         @error_queue.bind(@error_exchange, :routing_key => '#')
 
         # Finally, bind the worker queue to our requeue exchange
@@ -186,6 +186,15 @@ module Sneakers
       end
       private :log_prefix
 
+      private
+
+      def queue_durable?
+        @opts.fetch(:queue_options, {}).fetch(:durable, false)
+      end
+
+      def exchange_durable?
+        queue_durable?
+      end
     end
   end
 end

--- a/spec/sneakers/worker_handlers_spec.rb
+++ b/spec/sneakers/worker_handlers_spec.rb
@@ -132,7 +132,9 @@ describe 'Handlers' do
     before(:each) do
       @opts = {
         :exchange => 'sneakers',
-        :durable => 'true',
+        :queue_options => {
+          :durable => 'true',
+        }
       }.tap do |opts|
         opts[:retry_max_times] = max_retries unless max_retries.nil?
       end


### PR DESCRIPTION
This fixes a problem introduced in 4cf82d5700 where `:durable` as a general option is now deleted during worker start. This change now uses the new setting.