### PR TITLE
Dependency: ensure at least serverengine 1.5.11 is used

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(/^bin/).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
-  gem.add_dependency 'serverengine', '~> 1.5.5'
+  gem.add_dependency 'serverengine', '~> 1.5.11'
   gem.add_dependency 'bunny', '~> 2.2.0'
   gem.add_dependency 'thread', '~> 0.1.7'
   gem.add_dependency 'thor'


### PR DESCRIPTION
This is related to a livelock issue described here: https://github.com/fluent/serverengine/issues/21