### PR TITLE
Remove incorrect plural from constant name

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -14,7 +14,7 @@ namespace :sneakers do
     end
 
     if ENV["WORKERS"].nil?
-      workers = Sneakers::Workers::Classes
+      workers = Sneakers::Worker::Classes
     else
       workers, missing_workers = Sneakers::Utils.parse_workers(ENV['WORKERS'])
     end


### PR DESCRIPTION
Fixes a typo introduced in 7b4079b251ade2301562917be2f8c4edcae619bc that keeps the process from starting unless you set the `WORKERS` environment variable.