### PR TITLE
Add queue message to #worker_error for better diagnostics

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -61,11 +61,11 @@ module Sneakers
           end
         rescue Timeout::Error
           res = :timeout
-          worker_error('timeout')
+          worker_error('timeout',msg)
         rescue => ex
           res = :error
           error = ex
-          worker_error('unexpected error', ex)
+          worker_error('unexpected error', msg, ex)
         end
 
         if @should_ack
@@ -109,8 +109,8 @@ module Sneakers
     end
 
     # Helper to log an error message with an optional exception
-    def worker_error(msg, exception = nil)
-      s = log_msg(msg)
+    def worker_error(error_msg, queue_message, exception = nil)
+      s = log_msg("error:'#{error_msg}' message:'#{queue_message}'")
       if exception
         s += " [Exception error=#{exception.message.inspect} error_class=#{exception.class}"
         s += " backtrace=#{exception.backtrace.take(50).join(',')}" unless exception.backtrace.nil?

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -255,7 +255,7 @@ describe Sneakers::Worker do
       handler = Object.new
       header = Object.new
       mock(handler).error(header, nil, "msg", anything)
-      mock(w.logger).error(/unexpected error \[Exception error="foo" error_class=RuntimeError backtrace=.*/)
+      mock(w.logger).error(/error:'unexpected error' message:'msg' \[Exception error="foo" error_class=RuntimeError backtrace=.*/)
       w.do_work(header, nil, "msg", handler)
     end
 
@@ -375,8 +375,8 @@ describe Sneakers::Worker do
     describe '#worker_error' do
       it 'only logs backtraces if present' do
         w = DummyWorker.new(@queue, TestPool.new)
-        mock(w.logger).error(/cuz \[Exception error="boom!" error_class=RuntimeError\]/)
-        w.worker_error('cuz', RuntimeError.new('boom!'))
+        mock(w.logger).error(/error:'cuz' message:'some json' \[Exception error="boom!" error_class=RuntimeError\]/)
+        w.worker_error('cuz', 'some json', RuntimeError.new('boom!'))
       end
     end
 


### PR DESCRIPTION
I am building a slew of microservices and apps using Sneakers and would like to have the actual Rabbit/do_work message logged in `worker_error` so I can trace back the message to the producer. 

Thanks