### PR TITLE
Support for fatal (non-retriable) errors

### DIFF
--- a/lib/sneakers/handlers/oneshot.rb
+++ b/lib/sneakers/handlers/oneshot.rb
@@ -18,6 +18,10 @@ module Sneakers
         reject(hdr, props, msg)
       end
 
+      def fatal(hdr, props, msg, err)
+        error(hdr, props, msg, err)
+      end
+
       def timeout(hdr, props, msg)
         reject(hdr, props, msg)
       end


### PR DESCRIPTION
This commit is an outline of how support for fatal (non-retriable)
errors could be integrated into sneakers in a backwards-compatible way.
This is useful for handling messages that can never succeed (e.g.
poison messages) which at the moment will be retried in the `Maxretry`
handler rather than going straight to the error queue.

Note that although this is (I believe) a functionally complete
implementation the tests are not complete, as I want to gauge interest
and reaction to this before spending too much time on it. If there is
interest then I'm happy to implement all the necessary tests & docs.

Another option (either as well as, or instead of, having `FatalError`)
would be to designate a set of error types as fatal, e.g. when you're
parsing a JSON input you may get a `JSON::ParserError` which you
are not going to want to repeatedly retry.