### PR TITLE
Add Sneakers::ErrorReporter

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -75,6 +75,16 @@ module Sneakers
     yield self if server?
   end
 
+  # Register a proc to handle any error which occurs within the Sneakers process.
+  #
+  #   Sneakers.error_reporters << proc {|ex,ctx_hash| MyErrorService.notify(ex, ctx_hash) }
+  #
+  # The default error handler logs errors to Sneakers.logger.
+  # Ripped off from https://github.com/mperham/sidekiq/blob/6ad6a3aa330deebd76c6cf0d353f66abd3bef93b/lib/sidekiq.rb#L165-L174
+  def error_reporters
+    CONFIG[:error_reporters]
+  end
+
   private
 
   def setup_general_logger!

--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -1,3 +1,4 @@
+require 'sneakers/error_reporter'
 require 'forwardable'
 
 module Sneakers
@@ -21,6 +22,10 @@ module Sneakers
     }.freeze
 
     DEFAULTS = {
+      # Set up default handler which just logs the error.
+      # Remove this in production if you don't want sensitive data logged.
+      :error_reporters => [Sneakers::ErrorReporter::DefaultLogger.new],
+
       # runner
       :runner_config_file => nil,
       :metrics            => nil,

--- a/lib/sneakers/error_reporter.rb
+++ b/lib/sneakers/error_reporter.rb
@@ -1,0 +1,27 @@
+# Ripped off from https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/exception_handler.rb
+module Sneakers
+  module ErrorReporter
+    class DefaultLogger
+      def call(exception, context_hash)
+        Sneakers.logger.warn(context_hash) unless context_hash.empty?
+        log_string = ''
+        log_string += "[Exception error=#{exception.message.inspect} error_class=#{exception.class}" unless exception.nil?
+        log_string += " backtrace=#{exception.backtrace.take(50).join(',')}" unless exception.nil? || exception.backtrace.nil?
+        log_string += ']'
+        Sneakers.logger.error log_string
+      end
+    end
+
+    def worker_error(exception, context_hash = {})
+      Sneakers.error_reporters.each do |handler|
+        begin
+          handler.call(exception, context_hash)
+        rescue => inner_exception
+          Sneakers.logger.error '!!! ERROR REPORTER THREW AN ERROR !!!'
+          Sneakers.logger.error inner_exception
+          Sneakers.logger.error inner_exception.backtrace.join("\n") unless inner_exception.backtrace.nil?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #188
Closes #189 because will be able to do the following:
```ruby
Sneakers.error_handlers << Proc.new { |ex, context| Airbrake.notify_or_ignore(ex, parameters: context) }
```
Logs message on error by default like in #184 