### PR TITLE
Handle passing serverengine config in from runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 
+gem 'metric_fu' if RUBY_VERSION >= '2.1.0'
+gem 'simplecov'
+gem 'simplecov-rcov-text'
+gem 'guard'
+gem 'guard-minitest'
+gem 'nokogiri'
+gem 'ruby-prof'
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/gem_tasks"
-require 'metric_fu'
+require 'metric_fu' if RUBY_VERSION >= '2.1.0'
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine', '~> 1.5.11'
-  gem.add_dependency 'bunny', '~> 2.4.0'
+  gem.add_dependency 'bunny'
   gem.add_dependency 'thread', '~> 0.1.7'
   gem.add_dependency 'thor'
 

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine', '~> 1.5.11'
-  gem.add_dependency 'bunny', '~> 2.2.0'
+  gem.add_dependency 'bunny', '~> 2.4.0'
   gem.add_dependency 'thread', '~> 0.1.7'
   gem.add_dependency 'thor'
 

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -27,14 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'redis'
 
   gem.add_development_dependency 'rr'
-  gem.add_development_dependency 'ruby-prof'
-  gem.add_development_dependency 'nokogiri'
-  gem.add_development_dependency 'guard-minitest'
-  gem.add_development_dependency 'metric_fu'
-  gem.add_development_dependency 'simplecov'
-  gem.add_development_dependency 'simplecov-rcov-text'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
-  gem.add_development_dependency 'guard'
 end
 

--- a/spec/sneakers/runner_spec.rb
+++ b/spec/sneakers/runner_spec.rb
@@ -18,9 +18,10 @@ describe Sneakers::Runner do
         stub(daemon).main{ return 0 }
       end
 
-      @runner.run
-      # look at @runner's @se instance variable (actually of type Daemon)...and
-      # figure out what it's logger is...
+      @runner.run do |runner|
+        assert_instance_of(ServerEngine::Daemon, runner.server_engine)
+        assert_equal(logger, runner.server_engine.config[:logger])
+      end
     end
   end
 end


### PR DESCRIPTION
The `#run` method now accepts serverengine configuration options and
merges them against the server engine prior to the serverengine instance
having `#run` called on it.

Also support block acceptance on `#server_engine(&block)` which gives you
access to the runner that has `#server_engine` if you need to access that.
An internal, but an important one maybe worth sharing without too much
magic on the consumer side.

* Increased overall coverage & handled a couple TODOs which were solved
  by these changes.

```
  General coverage
     before: 91.78%
   new code: 91.34%
  new tests: 91.90%
      delta:  0.12%

  Coverage on lib/sneakers/runner.rb
     before: 73.81%
   new code: 72.00%
  new tests: 78.00%
      delta:  4.19%
```