### PR TITLE
allow classes to be an array

### DIFF
--- a/lib/sneakers/spawner.rb
+++ b/lib/sneakers/spawner.rb
@@ -13,8 +13,10 @@ module Sneakers
       @exec_string = "bundle exec rake sneakers:run"
       worker_config = YAML.load(File.read(worker_group_config_file))
       worker_config.keys.each do |group_name|
+        workers = worker_config[group_name]['classes']
+        workers = workers.join "," if workers.is_a?(Array)
         @pids << fork do
-          @exec_hash = {"WORKERS"=> worker_config[group_name]['classes'], "WORKER_COUNT" => worker_config[group_name]["workers"].to_s}
+          @exec_hash = {"WORKERS"=> workers, "WORKER_COUNT" => worker_config[group_name]["workers"].to_s}
           Kernel.exec(@exec_hash, @exec_string)
         end
       end


### PR DESCRIPTION
In order to make the config file more readable and maintainable