### PR TITLE
Allow to pass Proc as worker classes

### DIFF
--- a/lib/sneakers/workergroup.rb
+++ b/lib/sneakers/workergroup.rb
@@ -23,7 +23,13 @@ module Sneakers
       # when used with many workers.
       pool = config[:share_threads] ? Thread.pool(config[:threads]) : nil
 
-      @workers = config[:worker_classes].map{|w| w.new(nil, pool) }
+      worker_classes = config[:worker_classes]
+
+      if worker_classes.respond_to? :call
+        worker_classes = worker_classes.call
+      end
+
+      @workers = worker_classes.map{|w| w.new(nil, pool) }
       # if more than one worker this should be per worker
       # accumulate clients and consumers as well
       @workers.each do |worker|


### PR DESCRIPTION
This small PR gives ability to configure worker list in more flexible way.
Here is a pseudo-code usage example:

I. Put workers list in `workers.yaml`
```yaml
- FooWorker
```

II. [Run Sneakers programmatically](https://github.com/jondot/sneakers/wiki/How-to:-running-a-stand-alone-worker#running-sneakers-programmatically)
```
r = Sneakers::Runner.new -> { YAML.load_file('workers.yml').map(&:constantize) }
r.run
```

III. Edit `workers.yaml`
```yaml
- FooWorker
- BarWorker
```

IV. Run ```$ kill -SIGUSR1 `cat sneakers.pid` ``` to [gracefully restart sneakers](https://github.com/fluent/serverengine#signals).