### PR TITLE
Increased default AMQP heartbeat

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -34,7 +34,7 @@ module Sneakers
       :workers            => 4,
       :log                => STDOUT,
       :pid_path           => 'sneakers.pid',
-      :amqp_heartbeat     => 10,
+      :amqp_heartbeat     => 30,
 
       # workers
       :timeout_job_after  => 5,
@@ -42,7 +42,7 @@ module Sneakers
       :threads            => 10,
       :share_threads      => false,
       :ack                => true,
-      :heartbeat          => 2,
+      :heartbeat          => 30,
       :hooks              => {},
       :exchange           => 'sneakers',
       :exchange_options   => EXCHANGE_OPTION_DEFAULTS,


### PR DESCRIPTION
A ridiculously low heartbeat interval such as 2 seconds will just create false positives. Clients will throw `AMQ::Protocol::EmptyResponseError` if there's a slight glitch, one or few lost packages, in the network traffic and consumers will crash. A more sensible default is 30 seconds. See a similar discussion here: https://github.com/gocardless/hutch/issues/56