### PR TITLE
Ensure queue exists before publishing to avoid lost messages

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -21,6 +21,10 @@ module Sneakers
       :arguments => {}
     }.freeze
 
+    PUBLISHER_OPTION_DEFAULTS = {
+      :auto_declare_queue => true
+    }
+
     DEFAULTS = {
       # Set up default handler which just logs the error.
       # Remove this in production if you don't want sensitive data logged.
@@ -46,7 +50,8 @@ module Sneakers
       :hooks              => {},
       :exchange           => 'sneakers',
       :exchange_options   => EXCHANGE_OPTION_DEFAULTS,
-      :queue_options      => QUEUE_OPTION_DEFAULTS
+      :queue_options      => QUEUE_OPTION_DEFAULTS,
+      :publisher_options  => PUBLISHER_OPTION_DEFAULTS
     }.freeze
 
 

--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -8,6 +8,7 @@ module Sneakers
     def publish(msg, options = {})
       @mutex.synchronize do
         ensure_connection! unless connected?
+        ensure_queue!(options[:to_queue])
       end
       to_queue = options.delete(:to_queue)
       options[:routing_key] ||= to_queue
@@ -16,7 +17,7 @@ module Sneakers
     end
 
 
-    attr_reader :exchange
+    attr_reader :exchange, :queue
 
   private
     def ensure_connection!
@@ -35,6 +36,14 @@ module Sneakers
 
     def create_bunny_connection
       Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
+    end
+
+    def ensure_queue!(name)
+      # If the @queue attribute is already set, simply return
+      # otherwise declare+bind queue to ensure the msg is sent somewhere
+      return if @queue
+      @queue = @channel.queue(name, @opts[:queue_options])
+      @queue.bind(@exchange, routing_key: name)
     end
   end
 end

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -27,6 +27,7 @@ describe Sneakers::Publisher do
 
       p = Sneakers::Publisher.new
       p.instance_variable_set(:@exchange, xchg)
+      p.instance_variable_set(:@queue, xchg)
 
       mock(p).ensure_connection! {}
       p.publish('test msg', to_queue: 'downloads')
@@ -38,6 +39,7 @@ describe Sneakers::Publisher do
 
       p = Sneakers::Publisher.new
       p.instance_variable_set(:@exchange, xchg)
+      p.instance_variable_set(:@queue, xchg)
 
       mock(p).ensure_connection! {}
       p.publish('test msg', to_queue: 'downloads', persistence: true)
@@ -49,6 +51,7 @@ describe Sneakers::Publisher do
 
       p = Sneakers::Publisher.new
       p.instance_variable_set(:@exchange, xchg)
+      p.instance_variable_set(:@queue, xchg)
 
       mock(p).ensure_connection! {}
       p.publish('test msg', to_queue: 'downloads', expiration: 1, headers: {foo: 'bar'})
@@ -60,6 +63,7 @@ describe Sneakers::Publisher do
 
       p = Sneakers::Publisher.new
       p.instance_variable_set(:@exchange, xchg)
+      p.instance_variable_set(:@queue, xchg)
 
       mock(p).connected? { true }
       mock(p).ensure_connection!.times(0)
@@ -83,12 +87,14 @@ describe Sneakers::Publisher do
       end
 
       bunny = Object.new
+      queue = Object.new
       mock(bunny).start
       mock(bunny).create_channel { channel }
 
       mock(Bunny).new('amqp://someuser:somepassword@somehost:5672', heartbeat: 1, vhost: '/', logger: logger) { bunny }
 
       p = Sneakers::Publisher.new
+      p.instance_variable_set(:@queue, queue)
 
       p.publish('test msg', to_queue: 'downloads')
     end
@@ -97,6 +103,7 @@ describe Sneakers::Publisher do
       logger = Logger.new('/dev/null')
       channel = Object.new
       exchange = Object.new
+      queue = Object.new
       existing_session = Bunny.new
       my_vars = pub_vars.merge(to_queue: 'downloads')
 
@@ -119,6 +126,7 @@ describe Sneakers::Publisher do
       )
 
       p = Sneakers::Publisher.new
+      p.instance_variable_set(:@queue, queue)
       p.publish('test msg', my_vars)
       p.instance_variable_get(:@bunny).must_equal existing_session
     end

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -209,6 +209,9 @@ describe Sneakers::Worker do
             :exclusive => false,
             :arguments => {}
           },
+          :publisher_options => {
+            :auto_declare_queue => true
+          },
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 2,
@@ -248,6 +251,9 @@ describe Sneakers::Worker do
             :exclusive => true,
             :arguments => { 'x-arg' => 'value' }
           },
+          :publisher_options => {
+            :auto_declare_queue => true
+          },
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 5,
@@ -286,6 +292,9 @@ describe Sneakers::Worker do
             :auto_delete => false,
             :exclusive => false,
             :arguments => { 'x-arg2' => 'value2' }
+          },
+          :publisher_options => {
+            :auto_declare_queue => true
           },
           :hooks => {},
           :handler => Sneakers::Handlers::Oneshot,


### PR DESCRIPTION
Publishing to a queue that doesn't exist (or you could say an exchange that has no queues bound to it) will silently push the message into the cyber abyss. This can lead to an ugly data loss.

I think the publisher class should make sure and declare the queue to which it's publishing.  This way if the queues on the broker ever disappear (say in the event of a server crash/restart), our publisher will not naively publish a message into /dev/null.
