### PR TITLE
Disable Rake::TestTask warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.libs << "spec"
   t.test_files = FileList['spec/**/*_spec.rb']
+  t.warning = false
 end
 
 task default: :test


### PR DESCRIPTION
This will avoid noisy tests with lots of warnings introduced with
ruby/rake@8078bb6