### PR TITLE
Relax bunny version requirement

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine', '~> 1.5.11'
-  gem.add_dependency 'bunny', '~> 2.2.0'
+  gem.add_dependency 'bunny', '~> 2.2'
   gem.add_dependency 'thread', '~> 0.1.7'
   gem.add_dependency 'thor'
 


### PR DESCRIPTION
Current version of bunny (2.5.0) includes a lot of bug fixes relevant for
most production environments. This commit makes sneakers depending on
bunny '~> 2.2' and therefore allow all 2.x versions.