### PR TITLE
Shutdown worker pool before unregistering

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -93,6 +93,8 @@ module Sneakers
     end
 
     def stop
+      worker_trace "Stopping worker: shutting down thread pool."
+      @pool.shutdown
       worker_trace "Stopping worker: unsubscribing."
       @queue.unsubscribe
       worker_trace "Stopping worker: I'm gone."


### PR DESCRIPTION
This change will wait for workers to exit without taking new tasks before unregistering.