### PR TITLE
Pass `routing_key` to `Sneakers::Worker.publish` if available

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -131,8 +131,11 @@ module Sneakers
         @queue_opts = opts
       end
 
-      def enqueue(msg)
-        publisher.publish(msg, :to_queue => @queue_name)
+      def enqueue(msg, opts={})
+        opts[:routing_key] ||= @queue_opts[:routing_key]
+        opts[:to_queue] ||= @queue_name
+
+        publisher.publish(msg, opts)
       end
 
       private

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -159,19 +159,16 @@ describe Sneakers::Worker do
 
   describe ".enqueue" do
     it "publishes a message to the class queue" do
-      message = "my message"
-      mock = MiniTest::Mock.new
+      message = 'test message'
 
-      mock.expect(:publish, true) do |msg, opts|
-        msg.must_equal(message)
-        opts.must_equal(:to_queue => "defaults")
+      mock(Sneakers::Publisher).new(DummyWorker.queue_opts) do
+        mock(Object.new).publish(message, {
+          :routing_key => 'test.routing.key',
+          :to_queue    => 'downloads'
+        })
       end
-    end
 
-    it "passes the configuration to the publisher" do
-      opts = DummyWorker.queue_opts
-      mock(Sneakers::Publisher).new(opts) { mock(Object.new).publish(anything, anything) }
-      DummyWorker.enqueue(message)
+      DummyWorker.enqueue(message, :routing_key => 'test.routing.key')
     end
   end
 


### PR DESCRIPTION
Routing key can be defined via `.from_queue` and should be respected when publishing via the class method.