### PR TITLE
Add sneakers-specific timeout error

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -12,6 +12,7 @@ module Sneakers
 end
 
 require 'sneakers/configuration'
+require 'sneakers/errors'
 require 'sneakers/support/production_formatter'
 require 'sneakers/concerns/logging'
 require 'sneakers/concerns/metrics'

--- a/lib/sneakers/errors.rb
+++ b/lib/sneakers/errors.rb
@@ -1,0 +1,5 @@
+require 'timeout'
+
+module Sneakers
+  class WorkerTimeout < Timeout::Error; end
+end

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -51,7 +51,7 @@ module Sneakers
 
         begin
           metrics.increment("work.#{self.class.name}.started")
-          Timeout.timeout(@timeout_after, Timeout::Error) do
+          Timeout.timeout(@timeout_after, WorkerTimeout) do
             metrics.timing("work.#{self.class.name}.time") do
               if @call_with_params
                 res = work_with_params(msg, delivery_info, metadata)
@@ -60,7 +60,7 @@ module Sneakers
               end
             end
           end
-        rescue Timeout::Error => ex
+        rescue WorkerTimeout => ex
           res = :timeout
           worker_error(ex, log_msg: log_msg(msg), message: msg)
         rescue => ex

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -358,7 +358,7 @@ describe Sneakers::Worker do
       header = Object.new
 
       mock(handler).timeout(header, nil, "msg")
-      mock(w.logger).error(/error="execution expired" error_class=Timeout::Error backtrace=/)
+      mock(w.logger).error(/error="execution expired" error_class=Sneakers::WorkerTimeout backtrace=/)
 
       w.do_work(header, nil, "msg", handler)
     end


### PR DESCRIPTION
This distinguishes sneakers job timeouts from timeouts raised by
job code (e.g. an http lib with connection timeout).

More details are available in the related issue.
Fixes #259