### PR TITLE
Add worker class name to error logging context hash

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -62,11 +62,13 @@ module Sneakers
           end
         rescue WorkerTimeout => ex
           res = :timeout
-          worker_error(ex, log_msg: log_msg(msg), message: msg, delivery_info: delivery_info, metadata: metadata)
+          worker_error(ex, log_msg: log_msg(msg), class: self.class.name,
+                       message: msg, delivery_info: delivery_info, metadata: metadata)
         rescue => ex
           res = :error
           error = ex
-          worker_error(ex, log_msg: log_msg(msg), message: msg, delivery_info: delivery_info, metadata: metadata)
+          worker_error(ex, log_msg: log_msg(msg), class: self.class.name,
+                       message: msg, delivery_info: delivery_info, metadata: metadata)
         end
 
         if @should_ack


### PR DESCRIPTION
The worker's class name is useful to report to error tracking tools like [sentry](https://sentry.io/).