### PR TITLE
Set properties on message to error queue

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -138,7 +138,8 @@ module Sneakers
             error: reason,
             num_attempts: num_attempts,
             failed_at: Time.now.iso8601,
-            payload: Base64.encode64(msg.to_s)
+            payload: Base64.encode64(msg.to_s),
+            properties: Base64.encode64(props.to_json)
           }.tap do |hash|
             if reason.is_a?(Exception)
               hash[:error_class] = reason.class.to_s

--- a/spec/sneakers/worker_handlers_spec.rb
+++ b/spec/sneakers/worker_handlers_spec.rb
@@ -252,6 +252,7 @@ describe 'Handlers' do
             data['error'].must_equal('reject')
             data['num_attempts'].must_equal(2)
             data['payload'].must_equal(Base64.encode64(:reject.to_s))
+            data['properties'].must_equal(Base64.encode64(@props_with_x_death.to_json))
             Time.parse(data['failed_at']).wont_be_nil
           end
 
@@ -267,6 +268,7 @@ describe 'Handlers' do
             data['error'].must_equal('reject')
             data['num_attempts'].must_equal(4)
             data['payload'].must_equal(Base64.encode64(:reject.to_s))
+            data['properties'].must_equal(Base64.encode64(props_with_x_death_count.to_json))
             Time.parse(data['failed_at']).wont_be_nil
           end
 
@@ -316,6 +318,7 @@ describe 'Handlers' do
             data['error'].must_equal('timeout')
             data['num_attempts'].must_equal(2)
             data['payload'].must_equal(Base64.encode64(:timeout.to_s))
+            data['properties'].must_equal(Base64.encode64(@props_with_x_death.to_json))
             Time.parse(data['failed_at']).wont_be_nil
           end
         end
@@ -347,6 +350,7 @@ describe 'Handlers' do
             data['backtrace'].wont_be_nil
             data['num_attempts'].must_equal(2)
             data['payload'].must_equal(Base64.encode64('boom!'))
+            data['properties'].must_equal(Base64.encode64(@props_with_x_death.to_json))
             Time.parse(data['failed_at']).wont_be_nil
           end
         end
@@ -383,6 +387,7 @@ describe 'Handlers' do
           data['error'].must_equal('timeout')
           data['num_attempts'].must_equal(2)
           data['payload'].must_equal(Base64.encode64(payload.to_json))
+          data['properties'].must_equal(Base64.encode64(@props_with_x_death.to_json))
         end
 
       end


### PR DESCRIPTION
When my application tries to re-queue a error message, It lost properties data like: timestamp, app_id, message_id and headers.

This PR add the original properties in the error message. 

If anyone knows a better way to re-queue a error message, I will be very glad.