### PR TITLE
Add license to gemspec.

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q( Fast background processing framework for Ruby and RabbitMQ )
   gem.summary       = %q( Fast background processing framework for Ruby and RabbitMQ )
   gem.homepage      = 'http://sneakers.io'
+  gem.license       = 'MIT'
   gem.required_ruby_version = Gem::Requirement.new(">= 2.0")
 
   gem.files         = `git ls-files`.split($/).reject { |f| f == 'Gemfile.lock' }


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com/ruby/sneakers/2.5.0) and we primarily are reading license information from package manager APIs. Accepting this pull request would help us to improve our meta data. Many Thanks. 