### PR TITLE
Fix shutdown

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -65,7 +65,7 @@ class Sneakers::Queue
       Sneakers.logger.info "Queue: #{cancel_ok.consumer_tag} cancelled"
       @consumer = nil
     else
-      Sneakers.logger.warn "Queue: could not cancel#{@consume.inspect}"
+      Sneakers.logger.warn "Queue: could not cancel #{@consumer.inspect}"
       sleep(1)
       unsubscribe
     end

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -56,9 +56,19 @@ class Sneakers::Queue
   end
 
   def unsubscribe
+    return unless @consumer
+
     # XXX can we cancel bunny and channel too?
-    @consumer.cancel if @consumer
-    @consumer = nil
+    Sneakers.logger.info("Queue: Trying to unsubscribe on #{@consumer.inspect}")
+    cancel_ok = @consumer.cancel
+    if cancel_ok
+      Sneakers.logger.info "Queue: #{cancel_ok.consumer_tag} cancelled"
+      @consumer = nil
+    else
+      Sneakers.logger.warn "Queue: could not cancel#{@consume.inspect}"
+      sleep(1)
+      unsubscribe
+    end
   end
 
   def create_bunny_connection

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -95,10 +95,10 @@ module Sneakers
     end
 
     def stop
-      worker_trace "Stopping worker: shutting down thread pool."
-      @pool.shutdown
       worker_trace "Stopping worker: unsubscribing."
       @queue.unsubscribe
+      worker_trace "Stopping worker: shutting down thread pool."
+      @pool.shutdown
       worker_trace "Stopping worker: I'm gone."
     end
 

--- a/spec/sneakers/integration_spec.rb
+++ b/spec/sneakers/integration_spec.rb
@@ -85,39 +85,42 @@ describe "integration" do
       pid
     end
 
-    def alive?(pid)
-      if File.exist? "/proc"
-        # we're on Linux
-        return File.exists? "/proc/#{pid}"
-      else
-        Process.wait
-        Process.kill(0, pid.to_i)
-        true
+    def any_consumers
+      rmq_addr = compose_or_localhost("rabbitmq")
+      result = false
+      begin
+        admin = RabbitMQ::HTTP::Client.new("http://#{rmq_addr}:15672/", username: "guest", password: "guest")
+        qs = admin.list_queues
+        qs.each do |q|
+          if q.name.start_with? 'integration_'
+            puts "We see #{q.consumers} consumers on #{q.name}"
+            return true if q.consumers > 0
+          end
+        end
+        return false
+      rescue
+        puts "Rabbitmq admin seems to not exist? you better be running this on Travis or Docker. proceeding.\n#{$!}"
       end
-    rescue Errno::ESRCH # No such process
-      false
-    rescue Errno::EPERM # The process exists, but you dont have permission to send the signal to it.
-      true
     end
 
     it 'should be possible to terminate when queue is full' do
-      job_count = 30000
+      job_count = 40000
 
       pid = start_worker(IntegrationWorker)
       Process.kill("TERM", pid)
 
-      integration_log "publishing..."
+      integration_log "publishing #{job_count} messages..."
       p = Sneakers::Publisher.new
       job_count.times do |i|
         p.publish("m #{i}", to_queue: IntegrationWorker.queue_name)
       end
 
       pid = start_worker(IntegrationWorker)
+      any_consumers.must_equal true
       integration_log "Killing #{pid} now!"
       Process.kill("TERM", pid)
-      sleep(10)
-      integration_log "Checking if #{pid} is killed now!"
-      alive?(pid).must_equal false
+      sleep(2)
+      any_consumers.must_equal false
     end
 
     it 'should pull down 100 jobs from a real queue' do


### PR DESCRIPTION
I have had a problem with workers not shutting down when killed gracefully.

This seems to fix the problem for me.

The fix is basically swapping the order of `@queue.unsubscribe` and `@pool.shutdown`.

Before this, I would get a lot of R12 errors on Heroku. Probably at every restart.

Here is what Heroku says about R12:

    A process failed to exit within 30 seconds of being sent
    a SIGTERM indicating that it should stop. 
    The process is sent SIGKILL to force an exit.

After running with this in production on Heroku, I've still seen some H12. But not at every restart.

Also, when I run the spec, without swapping the order, I frequently get this error:

    2017-04-12T13:37:44Z p-55758 t-ox3doq5fw ERROR: Uncaught exception from consumer #<Bunny::Consumer:70300013132440 @channel_id=1 @queue=integration_10qfne2z2cf0btb9z90h71qj> @consumer_tag=bunny-1492004259000-703809509786>: #<RuntimeError: unable to add work while shutting down> @ /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/thread-0.1.7/lib/thread/pool.rb:252:in `block in process!'