### PR TITLE
Ability to pass 'properties' to Bunny session

### DIFF
--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -34,8 +34,10 @@ module Sneakers
     end
 
     def create_bunny_connection
-      Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
+      Bunny.new(@opts[:amqp], :vhost => @opts[:vhost],
+                              :heartbeat => @opts[:heartbeat],
+                              :properties => @opts.fetch(:properties, {}),
+                              :logger => Sneakers::logger)
     end
   end
 end
-

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -62,7 +62,10 @@ class Sneakers::Queue
   end
 
   def create_bunny_connection
-    Bunny.new(@opts[:amqp], :vhost => @opts[:vhost], :heartbeat => @opts[:heartbeat], :logger => Sneakers::logger)
+    Bunny.new(@opts[:amqp], :vhost => @opts[:vhost],
+                            :heartbeat => @opts[:heartbeat],
+                            :properties => @opts.fetch(:properties, {}),
+                            :logger => Sneakers::logger)
   end
   private :create_bunny_connection
 end

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -75,6 +75,7 @@ describe Sneakers::Publisher do
         exchange: 'another_exchange',
         exchange_options: { :type => :topic, :arguments => { 'x-arg' => 'value' } },
         log: logger,
+        properties: { key: "value" },
         durable: false)
 
       channel = Object.new
@@ -86,7 +87,7 @@ describe Sneakers::Publisher do
       mock(bunny).start
       mock(bunny).create_channel { channel }
 
-      mock(Bunny).new('amqp://someuser:somepassword@somehost:5672', heartbeat: 1, vhost: '/', logger: logger) { bunny }
+      mock(Bunny).new('amqp://someuser:somepassword@somehost:5672', heartbeat: 1, vhost: '/', logger: logger, properties: { key: "value" }) { bunny }
 
       p = Sneakers::Publisher.new
 


### PR DESCRIPTION
With this change we will be able to define a `properties` property in the `Sneakers` configuration, that will be passed to `Bunny` when a connection is created.

```ruby
Sneakers.configure({
  amqp: 'amqp://guest:guest@localhost:5672',
  properties: {
    key: "value",
    key2: "value2"
  }
})
```

This can be useful, for example, to identify where a connection is coming from, when we have dozens of applications using a `RabbitMQ` instance.

This is something that can already be done with `Bunny`:

```ruby
Bunny.new(connection_string, { properties: { key: 'value' } })
```

So we are just leveraging that functionality when the connection is created from `Sneakers`.

These properties will be shown in the Management UI like this:

<img width="578" alt="screenshot 2017-04-12 14 38 28" src="https://cloud.githubusercontent.com/assets/183363/24971479/86962d10-1f8e-11e7-9165-3a4a921a5a0b.png">
