### PR TITLE
Replace gem thread with concurrent-ruby

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -1,5 +1,5 @@
-require "sneakers/version"
-require 'thread/pool'
+require 'sneakers/version'
+require 'concurrent/executors'
 require 'bunny'
 require 'logger'
 require 'serverengine'

--- a/lib/sneakers/workergroup.rb
+++ b/lib/sneakers/workergroup.rb
@@ -21,7 +21,7 @@ module Sneakers
 
       # Allocate single thread pool if share_threads is set. This improves load balancing
       # when used with many workers.
-      pool = config[:share_threads] ? Thread.pool(config[:threads]) : nil
+      pool = config[:share_threads] ? Concurrent::FixedThreadPool.new(config[:threads]) : nil
 
       worker_classes = config[:worker_classes]
 

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.add_dependency 'serverengine', '~> 1.5.11'
   gem.add_dependency 'bunny', '~> 2.7.0'
-  gem.add_dependency 'thread', '~> 0.1.7'
+  gem.add_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_dependency 'thor'
 
   # for integration environment (see .travis.yml and integration_spec)

--- a/spec/sneakers/worker_handlers_spec.rb
+++ b/spec/sneakers/worker_handlers_spec.rb
@@ -36,12 +36,7 @@ class HandlerTestWorker
   end
 end
 
-class TestPool
-  def process(*args,&block)
-    block.call
-  end
-end
-
+TestPool ||= Concurrent::ImmediateExecutor
 
 describe 'Handlers' do
   let(:channel) { Object.new }

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -87,8 +87,6 @@ class JSONPublishingWorker
   end
 end
 
-
-
 class LoggingWorker
   include Sneakers::Worker
   from_queue 'defaults',
@@ -108,7 +106,6 @@ class JSONWorker
   def work(msg)
   end
 end
-
 
 class MetricsWorker
   include Sneakers::Worker
@@ -145,11 +142,7 @@ class WithDeprecatedExchangeOptionsWorker
   end
 end
 
-class TestPool
-  def process(*args,&block)
-    block.call
-  end
-end
+TestPool ||= Concurrent::ImmediateExecutor
 
 def with_test_queuefactory(ctx, ack=true, msg=nil, nowork=false)
   qf = Object.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require 'rr'
 
 def compose_or_localhost(key)
   Resolv::DNS.new.getaddress(key)
-rescue 
+rescue
   "localhost"
 end
 


### PR DESCRIPTION
concurrent-ruby is today the reference gem when it comes to concurrent data
structures and concurrency primitives.

Nothing against gem thread, is just that concurrent-ruby is simply much better
documented and actively maintained.