### PR TITLE
Change log level of configuration inspection to debug

### DIFF
--- a/lib/sneakers/runner.rb
+++ b/lib/sneakers/runner.rb
@@ -58,8 +58,7 @@ module Sneakers
         Sneakers::CONFIG[:hooks][hook] = config.delete(hook) if config[hook]
       end
 
-
-      Sneakers.logger.info("New configuration: #{config.inspect}")
+      Sneakers.logger.debug("New configuration: #{config.inspect}")
       config
     end
 


### PR DESCRIPTION
Fixes #300 

Changes log level of worker configuration inspection  to DEBUG to avoid leaking rabbitmq credentials to log files in production mode.
