### PR TITLE
Use provided shared connection in WorkerGroup

### DIFF
--- a/spec/sneakers/runner_spec.rb
+++ b/spec/sneakers/runner_spec.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'spec_helper'
 require 'sneakers'
+require 'sneakers/runner'
 
 describe Sneakers::Runner do
   let(:logger) { Logger.new('logtest.log') }
@@ -29,10 +30,10 @@ describe Sneakers::RunnerConfig do
   let(:logger) { Logger.new("logtest.log") }
   let(:runner_config) { Sneakers::Runner.new([]).instance_variable_get("@runnerconfig") }
 
-
-
   describe "with a connection" do
-    before { Sneakers.configure(log: logger, connection: Object.new) }
+    let(:connection) { Object.new }
+
+    before { Sneakers.configure(log: logger, connection: connection) }
 
     describe "#reload_config!" do
       it "does not throw exception" do
@@ -45,6 +46,10 @@ describe Sneakers::RunnerConfig do
 
       it "must have :logger key as an instance of Logger" do
         runner_config.reload_config![:logger].is_a?(Logger).must_equal true
+      end
+
+      it "must have :connection" do
+        runner_config.reload_config![:connection].is_a?(Object).must_equal true
       end
     end
   end

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -313,6 +313,22 @@ describe Sneakers::Worker do
         DummyWorker.new.id.must_match(/^worker-/)
       end
     end
+
+    describe 'when connection provided' do
+      before do
+        @connection = Bunny.new(host: 'any-host.local')
+        Sneakers.configure(
+          exchange:          'some-exch',
+          exchange_options:  { type: :direct },
+          connection:        @connection,
+        )
+      end
+
+      it "should build a queue with given connection" do
+        @dummy_q = DummyWorker.new.queue
+        @dummy_q.opts[:connection].must_equal(@connection)
+      end
+    end
   end
 
 

--- a/spec/sneakers/workergroup_spec.rb
+++ b/spec/sneakers/workergroup_spec.rb
@@ -1,0 +1,83 @@
+require 'logger'
+require 'spec_helper'
+require 'sneakers'
+require 'sneakers/runner'
+
+class DummyFlag
+  def wait_for_set(*)
+    true
+  end
+end
+
+class DummyEngine
+  include Sneakers::WorkerGroup
+
+  attr_reader :config
+
+  def initialize(config)
+    @config = config
+    @stop_flag = DummyFlag.new
+  end
+end
+
+class DefaultsWorker
+  include Sneakers::Worker
+  from_queue 'defaults'
+
+  def work(msg); end
+end
+
+class StubbedWorker
+  attr_reader :opts
+
+  def initialize(_, _, opts)
+    @opts = opts
+  end
+
+  def run
+    true
+  end
+end
+
+describe Sneakers::WorkerGroup do
+  let(:logger) { Logger.new('logtest.log') }
+  let(:connection) { Bunny.new(host: 'any-host.local') }
+  let(:runner) { Sneakers::Runner.new([DefaultsWorker]) }
+  let(:runner_config) { runner.instance_variable_get('@runnerconfig') }
+  let(:config) { runner_config.reload_config! }
+  let(:engine) { DummyEngine.new(config) }
+
+  describe '#run' do
+    describe 'with connecion provided' do
+      before do
+        Sneakers.clear!
+        Sneakers.configure(connection: connection, log: logger, share_bunny_connection: true)
+      end
+
+      it 'creates workers with connection: connection' do
+        DefaultsWorker.stub(:new, ->(*args) { StubbedWorker.new(*args) }) do
+          engine.run
+
+          workers = engine.instance_variable_get('@workers')
+          workers.first.opts[:connection].must_equal(connection)
+        end
+      end
+    end
+
+    describe 'without connecion provided' do
+      before do
+        Sneakers.clear!
+        Sneakers.configure(log: logger)
+      end
+
+      it 'creates workers with connection: nil' do
+        DefaultsWorker.stub(:new, ->(*args) { StubbedWorker.new(*args) }) do
+          engine.run
+
+          workers = engine.instance_variable_get('@workers')
+          assert_nil(workers.first.opts[:connection])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've faced an issue with Bunny connection provided to `Sneakers.configure` and WorkerGroup.
Having the following config:

~~~ruby
connection = Bunny.new(@config)

Sneakers.configure exchange:                'ex',
                   exchange_options:        { type: :direct },
                   connection:              connection
~~~

I get a bunch of connection errors after switching from stable **2.5** release to Sneakers **master** branch.

After thorough investigation I found the root of the problem: WorkerGroup keeps creating a new connection even though I provide one in `Sneakers.configure` (and moreover it uses `:amqp` config param that I don't provide).

The solution here is using preconfigured connection in WorkerGroup and enabling it with `:share_bunny_connection` flag.

Any suggestions about PR? Should we use `:share_bunny_connection` flag or just check existence of `:connection` config param?