### PR TITLE
Bump to 2.6.0

### DIFF
--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "2.5.0"
+  VERSION = "2.6.0"
 end


### PR DESCRIPTION
See the [diff between v2.5.0 and master](https://github.com/jondot/sneakers/compare/v2.5.0...master). Looks like a minor version bump to me. Proposed changelog/release notes:
- Added licence type to gemspec #274
- Serialization content type configuration #152 
- Add NewRelic category to example #273
- Pass additional global Bunny session configuration #276 
- `Sneaker.spawn` exits with `exit_code` `1` when no configuration is provided #280 
- Added opt-in option for sharing bunny connections for worker group #266
- Bumped bunny version from 2.6.* to 2.7.*. #289
- Relaced `thread` gem with `concurrent-ruby` gem #279
- Fixed "stack level to deep" error when trying to serialize the exception object in maxretry handler #308

Is #279 the one that has the greatest chance of side-effects in production?