### PR TITLE
Allow specify another exchange in Publisher#publish options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 tmp/
 .ruby-version
 .ruby-gemset
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ RUN apk --update add --virtual build_deps \
 build-base ruby-dev libc-dev linux-headers \
 openssl-dev
 
-ADD . /sneakers
 WORKDIR /sneakers
 
+COPY Gemfile sneakers.gemspec ./
+COPY lib/sneakers/version.rb lib/sneakers/version.rb
+
 RUN bundle --jobs=4 --retry=3
+
+COPY . .
 
 CMD rake test


### PR DESCRIPTION
You dont have to create separate publishers for all exchanges, now you can just write:
`Sneakers::Publisher.new.publish('Some message', exchange: 'another-exchange')`
Also you can specify exchange options too:
```
options = {
  routing_key: 'downloads',
  exchange: 'another-exchange',
  exchange_options: {
  type: :topic,
    durable: true,
    arguments: {'x-arg' => 'value' }
  }
}
Sneakers::Publisher.new.publish('Some message', options)
```
