### PR TITLE
Use existing connection if specified in config

### DIFF
--- a/lib/sneakers/workergroup.rb
+++ b/lib/sneakers/workergroup.rb
@@ -63,6 +63,7 @@ module Sneakers
     end
 
     def create_connection_or_nil
+      return Sneakers::CONFIG[:connection] unless Sneakers::CONFIG[:connection].nil?
       config[:share_bunny_connection] ? create_bunny_connection : nil
     end
     private :create_bunny_connection, :create_connection_or_nil

--- a/spec/sneakers/workergroup_spec.rb
+++ b/spec/sneakers/workergroup_spec.rb
@@ -1,0 +1,43 @@
+require 'logger'
+require 'spec_helper'
+require 'sneakers'
+require 'sneakers/workergroup'
+
+class TestWorkerGroup
+  include Sneakers::WorkerGroup
+  def config
+    {}
+  end
+end
+
+describe Sneakers::WorkerGroup do
+  describe "create_connection_or_nil" do
+    before do
+      Sneakers.configure(config)
+    end
+
+    let(:worker_group) { TestWorkerGroup.new }
+
+    describe "with a connection in sneakers config" do
+      let(:connection) { Bunny.new }
+      let(:config) {
+        {
+          connection: connection
+        }
+      }
+
+      it 'uses specified connection' do
+        worker_group.send(:create_connection_or_nil).must_equal(connection)
+      end
+    end
+
+    describe "without a connection in sneakers config" do
+      let(:config) { {} }
+
+      it 'returns nil' do
+        worker_group.send(:create_connection_or_nil).must_be_nil
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
The changes in #266 break sneakers if you are specifying a `:connection` in your config. This PR should fix it. I added a test against a private method, which I normally wouldn't do, but it seemed like the expedient way to test the bug.