### PR TITLE
Refactor New Relic usage

### DIFF
--- a/lib/sneakers/metrics/newrelic_metrics.rb
+++ b/lib/sneakers/metrics/newrelic_metrics.rb
@@ -15,7 +15,8 @@ module Sneakers
       end
 
       def record_stat(metric, num)
-        stats(metric).record_data_point(num)
+        metric_name = "Custom/#{metric.gsub("\.", "\/")}"
+        NewrelicMetrics.eagent::Agent.record_metric(metric_name, num)
       rescue Exception => e
         puts "NewrelicMetrics#record_stat: #{e}"
       end
@@ -25,12 +26,6 @@ module Sneakers
         block.call
         record_stat(metric, ((Time.now - start)*1000).floor)
       end
-
-      def stats(metric)
-        metric.gsub! "\.", "\/"
-        NewrelicMetrics.eagent::Agent.get_stats("Custom/#{metric}")
-      end
-
     end
   end
 end


### PR DESCRIPTION
Metrics were recorded through a deprecated API, added support for the newer one.

As you can see here, the `get_stats` method was deprecated and the suggested change is 
> If you had chained `get_stats` with `record_data_point`, use:
`NewRelic::Agent.record_metric`

https://docs.newrelic.com/docs/agents/ruby-agent/installation/upgrade-ruby-agent-versions