### PR TITLE
update serverengine gem to 2.0.5

### DIFF
--- a/lib/sneakers/runner.rb
+++ b/lib/sneakers/runner.rb
@@ -72,6 +72,7 @@ module Sneakers
       serverengine_config =  Sneakers::CONFIG.merge(@conf)
       serverengine_config.merge!(
         :logger => Sneakers.logger,
+        :log_level => Sneakers.logger.level,
         :worker_type => 'process',
         :worker_classes => @worker_classes,
 

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(/^bin/).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
-  gem.add_dependency 'serverengine', '~> 1.5.11'
+  gem.add_dependency 'serverengine', '~> 2.0.5'
   gem.add_dependency 'bunny', '~> 2.7.1'
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_dependency 'thor'
@@ -37,4 +37,3 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'guard'
 end
-


### PR DESCRIPTION
* add the log_level option for serverengine
otherwise it gets resetted there
* for details what changed in serverengine, see
https://github.com/treasure-data/serverengine/blob/master/Changelog