### PR TITLE
Casually start defining classes based on jobs defining perform in Rails

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -37,6 +37,20 @@ EOF
       exit(1)
     end
     opts = (!ENV['WORKER_COUNT'].nil? ? {:workers => ENV['WORKER_COUNT'].to_i} : {})
+    if defined?(::Rails) && defined?(::ActiveJob::Base)
+      workers -= [ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper]
+      jobs = ::ActiveJob::Base.descendants
+      not_abstract_jobs = jobs.select { |j| j.instance_methods.include?(:perform) }
+      workers += not_abstract_jobs.map do |job|
+        q = job.queue_name # From ActiveJob::QueueName.queue_name
+        q_name = q.is_a?(Proc) ? q[].to_s : q.to_s
+        worker_klass = "ActiveJobWorker" + Digest::MD5.hexdigest(q_name) # From rails/activejob/test/support/integration/adapters/sneakers.rb
+        Sneakers.const_set(worker_klass, Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
+          from_queue q_name
+        end)
+        "Sneakers::#{worker_klass}".constantize
+      end
+    end
     r = Sneakers::Runner.new(workers, opts)
 
     r.run


### PR DESCRIPTION
Fixes #330 
Also attempt at rails/rails#29478

This PR defines one worker per Job that defines Perform, and sets it's queue to whatever queue_name resolves to after processing.