### PR TITLE
Worker group ignores connection option

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -79,6 +79,7 @@ module Sneakers
           hash.delete(k)
           @hash.delete(k)
         end
+        hash.merge!(share_bunny_connection: true) # Share the connection when set.
       end
 
       @hash = deep_merge(@hash, hash)

--- a/lib/sneakers/workergroup.rb
+++ b/lib/sneakers/workergroup.rb
@@ -59,7 +59,10 @@ module Sneakers
     end
 
     def create_bunny_connection
-      Bunny.new(Sneakers::CONFIG[:amqp], :vhost => Sneakers::CONFIG[:vhost], :heartbeat => Sneakers::CONFIG[:heartbeat], :logger => Sneakers::logger)
+      config.fetch(
+        :connection,
+        Bunny.new(Sneakers::CONFIG[:amqp], :vhost => Sneakers::CONFIG[:vhost], :heartbeat => Sneakers::CONFIG[:heartbeat], :logger => Sneakers::logger)
+      )
     end
 
     def create_connection_or_nil


### PR DESCRIPTION
Started to use the connection option and realize that allways localhost was the target instead of another  host.
The tests are runnig but unfortunately I did not managed to create a test for it.

I hope the fix will be merge otherwise give me a short feedback.
Thanks. 