### PR TITLE
Fix Error Reporters Usage Description

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -79,7 +79,7 @@ module Sneakers
 
   # Register a proc to handle any error which occurs within the Sneakers process.
   #
-  #   Sneakers.error_reporters << proc {|ex,ctx_hash| MyErrorService.notify(ex, ctx_hash) }
+  #   Sneakers.error_reporters << proc { |exception, worker, context_hash| MyErrorService.notify(exception, context_hash) }
   #
   # The default error handler logs errors to Sneakers.logger.
   # Ripped off from https://github.com/mperham/sidekiq/blob/6ad6a3aa330deebd76c6cf0d353f66abd3bef93b/lib/sidekiq.rb#L165-L174


### PR DESCRIPTION
According to the definition [here](https://github.com/jondot/sneakers/blob/master/lib/sneakers/error_reporter.rb#L5) and default reporter call [here](https://github.com/jondot/sneakers/blob/master/lib/sneakers/error_reporter.rb#L18).

Also reflected error reporters at "Configuration" wiki page, new ["Error Reporters"](https://github.com/jondot/sneakers/wiki/Configuration#error-reporter) section.

    