### PR TITLE
Declare Rake as Runtime Dependency

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bunny', '~> 2.9.2'
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_dependency 'thor'
+  gem.add_dependency 'rake'
 
   # for integration environment (see .travis.yml and integration_spec)
   gem.add_development_dependency 'rabbitmq_http_api_client'


### PR DESCRIPTION
Sneakers runs primary within rake task `sneakers:run`, so it's fair to have `rake` gem as runtime dependency along with `thor`. This change will allow running `sneakers` in a bare Ruby application without `gem "rake"` in `Gemfile`.