### PR TITLE
Daemonize the sneakers started using rake task

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -37,8 +37,9 @@ EOF
       exit(1)
     end
     opts = (!ENV['WORKER_COUNT'].nil? ? {:workers => ENV['WORKER_COUNT'].to_i} : {})
-    r = Sneakers::Runner.new(workers, opts)
+    opts.merge!(daemonize: true) if ENV['DAEMONIZE'] == 'yes'
 
+    r = Sneakers::Runner.new(workers, opts)
     r.run
   end
 end


### PR DESCRIPTION
Currently, we use screen and nohup options to push the start the task in background mode. Hopefully after this fixes we would no longer have to do that.

Once accepted that the following options (I will) need to be updated on wiki page over [here](https://github.com/jondot/sneakers/wiki/How-To:-Rails-Background-Jobs)