### PR TITLE
BREAKING CHANGE: remove enforced Worker#work timeout

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -37,7 +37,6 @@ module Sneakers
       :amqp_heartbeat     => 30,
 
       # workers
-      :timeout_job_after  => 600,
       :prefetch           => 10,
       :threads            => 10,
       :share_threads      => false,

--- a/lib/sneakers/errors.rb
+++ b/lib/sneakers/errors.rb
@@ -1,5 +1,2 @@
-require 'timeout'
-
 module Sneakers
-  class WorkerTimeout < Timeout::Error; end
 end

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -5,7 +5,7 @@ module Sneakers
   module Handlers
     #
     # Maxretry uses dead letter policies on Rabbitmq to requeue and retry
-    # messages after failure (rejections, errors and timeouts). When the maximum
+    # messages after failure (rejections and errors). When the maximum
     # number of retries is reached it will put the message on an error queue.
     # This handler will only retry at the queue level. To accomplish that, the
     # setup is a bit complex.
@@ -99,10 +99,6 @@ module Sneakers
 
       def error(hdr, props, msg, err)
         handle_retry(hdr, props, msg, err)
-      end
-
-      def timeout(hdr, props, msg)
-        handle_retry(hdr, props, msg, :timeout)
       end
 
       def noop(hdr, props, msg)

--- a/lib/sneakers/handlers/oneshot.rb
+++ b/lib/sneakers/handlers/oneshot.rb
@@ -18,10 +18,6 @@ module Sneakers
         reject(hdr, props, msg)
       end
 
-      def timeout(hdr, props, msg)
-        reject(hdr, props, msg)
-      end
-
       def noop(hdr, props, msg)
 
       end


### PR DESCRIPTION
See #343 for the background. Worker implementations now must handle
timeouts in a way they see fit. This is unfortunate but there is no
way to enforce timeouts in a safe way without at least some Worker implementation
cooperation and currently there is no decision on what that should look like.

We previously increased the timeout to 10 minutes. This is about as good
as not having any, so let's rip off the bandaid.

Closes #343.