### PR TITLE
Support queue bind arguments

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -38,7 +38,11 @@ class Sneakers::Queue
 
     if exchange_name.length > 0
       routing_keys.each do |key|
-        queue.bind(@exchange, :routing_key => key)
+        if @opts.key?(:bind_arguments)
+          queue.bind(@exchange, :routing_key => key, arguments: @opts[:bind_arguments])
+        else
+          queue.bind(@exchange, :routing_key => key)
+        end
       end
     end
 

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -38,7 +38,7 @@ class Sneakers::Queue
 
     if exchange_name.length > 0
       routing_keys.each do |key|
-        if @opts.key?(:bind_arguments)
+        if @opts[:bind_arguments]
           queue.bind(@exchange, :routing_key => key, arguments: @opts[:bind_arguments])
         else
           queue.bind(@exchange, :routing_key => key)

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -74,6 +74,17 @@ describe Sneakers::Queue do
         q.subscribe(@mkworker)
       end
 
+      it "supports setting arguments when binding" do
+        mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
+        q = Sneakers::Queue.new("downloads",
+                                queue_vars.merge(:bind_arguments => { "os" => "linux", "cores" => 8 }))
+
+        mock(@mkqueue).bind(@mkex, :routing_key => "downloads", :arguments => { "os" => "linux", "cores" => 8 })
+        mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
+
+        q.subscribe(@mkworker)
+      end
+
       it "will use whatever handler the worker specifies" do
         mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
         @handler = Object.new


### PR DESCRIPTION
The arguments is used as rules for filtering messages when connected to an exchange of type "headers":
http://rubybunny.info/articles/exchanges.html#routing_on_multiple_message_attributes