### PR TITLE
Introduce middlewares

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,20 +9,16 @@ RUN apk --update add --virtual build_deps \
                                linux-headers \
                                openssl-dev
 
-RUN mkdir /myapp
-
 WORKDIR /sneakers
 
-COPY lib/sneakers/version.rb /sneakers/lib/sneakers/version.rb
+COPY lib/sneakers/version.rb lib/sneakers/version.rb
 
-COPY sneakers.gemspec /sneakers/sneakers.gemspec
+COPY sneakers.gemspec .
 
-COPY Gemfile /sneakers/Gemfile
-
-COPY Gemfile.lock /sneakers/Gemfile.lock
+COPY Gemfile* ./
 
 RUN bundle --jobs=4 --retry=3
 
-COPY . /sneakers
+COPY . .
 
 CMD rake test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     depends_on:
       - rabbitmq
       - redis
+    environment:
+      - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672
 
   rabbitmq:
     image: rabbitmq:management-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 services:
   sneakers:
     build: .
+    volumes:
+      - .:/sneakers
     depends_on:
       - rabbitmq
       - redis

--- a/examples/middleware_worker.rb
+++ b/examples/middleware_worker.rb
@@ -1,0 +1,34 @@
+$: << File.expand_path('../lib', File.dirname(__FILE__))
+require 'sneakers'
+require 'sneakers/runner'
+
+class MiddlewareWorker
+  include Sneakers::Worker
+
+  from_queue 'middleware-demo',
+    ack: false
+
+  def work(message)
+    puts "******** MiddlewareWorker -> #{message}"
+  end
+end
+
+class DemoMiddleware
+  def initialize(app, *args)
+    @app = app
+    @args = args
+  end
+
+  def call(deserialized_msg, delivery_info, metadata, handler)
+    puts "******** DemoMiddleware - before; args #{@args}"
+    @app.call(deserialized_msg, delivery_info, metadata, handler)
+    puts "******** DemoMiddleware - after"
+  end
+end
+
+Sneakers.configure
+Sneakers.middleware.use(DemoMiddleware, foo: :bar)
+
+Sneakers.publish("{}", :to_queue => 'middleware-demo')
+r = Sneakers::Runner.new([MiddlewareWorker])
+r.run

--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -18,6 +18,7 @@ require 'sneakers/concerns/logging'
 require 'sneakers/concerns/metrics'
 require 'sneakers/handlers/oneshot'
 require 'sneakers/content_type'
+require 'sneakers/middleware/config'
 require 'sneakers/worker'
 require 'sneakers/publisher'
 
@@ -85,6 +86,10 @@ module Sneakers
   # Ripped off from https://github.com/mperham/sidekiq/blob/6ad6a3aa330deebd76c6cf0d353f66abd3bef93b/lib/sidekiq.rb#L165-L174
   def error_reporters
     CONFIG[:error_reporters]
+  end
+
+  def middleware
+    @middleware ||= Sneakers::Middleware::Config
   end
 
   private

--- a/lib/sneakers/middleware/config.rb
+++ b/lib/sneakers/middleware/config.rb
@@ -1,0 +1,23 @@
+module Sneakers
+  module Middleware
+    class Config
+      def self.use(klass, args)
+        middlewares << { class: klass, args: args }
+      end
+
+      def self.delete(klass)
+        middlewares.reject! { |el| el[:class] == klass }
+      end
+
+      def self.to_a
+        middlewares
+      end
+
+      def self.middlewares
+        @middlewares ||= []
+      end
+
+      private_class_method :middlewares
+    end
+  end
+end

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -57,11 +57,20 @@ module Sneakers
         metrics.increment("work.#{self.class.name}.started")
         metrics.timing("work.#{self.class.name}.time") do
           deserialized_msg = ContentType.deserialize(msg, @content_type || metadata && metadata[:content_type])
-          if @call_with_params
-            res = work_with_params(deserialized_msg, delivery_info, metadata)
-          else
-            res = work(deserialized_msg)
+
+          app = -> (deserialized_msg, delivery_info, metadata, handler) do
+            if @call_with_params
+              work_with_params(deserialized_msg, delivery_info, metadata)
+            else
+              work(deserialized_msg)
+            end
           end
+
+          middlewares = Sneakers.middleware.to_a
+          block_to_call = middlewares.reverse.reduce(app) do |mem, h|
+            h[:class].new(mem, *h[:args])
+          end
+          res = block_to_call.call(deserialized_msg, delivery_info, metadata, handler)
         end
       rescue => ex
         res = :error

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov-rcov-text'
   gem.add_development_dependency 'guard'
   gem.add_development_dependency 'guard-minitest'
+  gem.add_development_dependency 'pry-byebug'
 end

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -382,6 +382,61 @@ describe Sneakers::Worker do
       w.do_work(header, nil, "msg", handler)
     end
 
+    describe 'middleware' do
+      let(:middleware) do
+        Class.new do
+          def initialize(app, *args)
+            @app = app
+          end
+
+          def call(deserialized_msg, delivery_info, metadata, handler)
+            @app.call(deserialized_msg, delivery_info, metadata, handler)
+          end
+        end
+      end
+
+      let(:worker) do
+        Class.new do
+          include Sneakers::Worker
+          from_queue 'defaults', ack: false
+
+          def work_with_params(msg, delivery_info, metadata)
+            msg
+          end
+        end
+      end
+
+      before do
+        Sneakers.middleware.use(middleware, 'args')
+
+        @delivery_info = Object.new
+        @metadata = Object.new
+        stub(@metadata).[](:content_type) { 'some/fake' }
+        @message = Object.new
+        @handler = Object.new
+      end
+
+      after do
+        Sneakers.middleware.delete(middleware)
+      end
+
+      it 'should process job and call #work_with_params/#work' do
+        w = worker.new(@queue, TestPool.new)
+        mock(w).work_with_params(@message, @delivery_info, @metadata).once
+
+        w.do_work(@delivery_info, @metadata, @message, @handler)
+      end
+
+      it "should call registered middleware" do
+        mock.proxy(middleware).new(instance_of(Proc), 'args').once do |res|
+          mock.proxy(res).call(@message, @delivery_info, @metadata, @handler).once
+        end
+
+        w = worker.new(@queue, TestPool.new)
+        w.do_work(@delivery_info, @metadata, @message, @handler)
+      end
+    end
+
     describe "with ack" do
       before do
         @delivery_info = Object.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'simplecov'
 require 'resolv'
+require 'pry-byebug'
 
 SimpleCov.start do
   add_filter "/spec/"


### PR DESCRIPTION
Related issue https://github.com/jondot/sneakers/pull/323

It allows to use custom hooks/middlewares while job is processed.
The interface is similar to Rails:

```ruby
Sneakers.middleware.use(<class>, arguments)
Sneakers.middleware.delete(<class>)
```

Rails documentation - https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack

Middleware should have following interface:

```ruby
class Middleware
  def initialize(app, <arguments>)
    ...
  end

  def call(message, delivery_info, metadata, handler)
    ...
  end
end
```

`#call` method should
- call next middleware passed into `#initialize` as `app` argument
- pass `message`, `delivery_info`, `metadata`, `handler` as arguments and
- modify and return result value.