### PR TITLE
Loosen Bunny dependency to minor version

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'serverengine', '~> 2.0.5'
-  gem.add_dependency 'bunny', '~> 2.11.0'
+  gem.add_dependency 'bunny', '~> 2.12'
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_dependency 'thor'
   gem.add_dependency 'rake'


### PR DESCRIPTION
Sneakers is currently locking us into a version of Bunny we don't want to be using because the version dependency is tied to the patch-level. Is there a reason for that? 

Currently we're locking people into patch versions of Bunny when the project clearly seems to be using SemVer and shouldn't have API breaking changes in minor versions. So this change should make sense.

See: https://github.com/ruby-amqp/bunny/blob/master/ChangeLog.md