### PR TITLE
Rescue from ScriptError

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -63,7 +63,7 @@ module Sneakers
             res = work(deserialized_msg)
           end
         end
-      rescue => ex
+      rescue StandardError, ScriptError => ex
         res = :error
         error = ex
         worker_error(ex, log_msg: log_msg(msg), class: self.class.name,

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -372,6 +372,16 @@ describe Sneakers::Worker do
       w.do_work(header, nil, "msg", handler)
     end
 
+    it "should catch script exceptions from a bad work" do
+      w = AcksWorker.new(@queue, TestPool.new)
+      mock(w).work("msg").once{ raise ScriptError }
+      handler = Object.new
+      header = Object.new
+      mock(handler).error(header, nil, "msg", anything)
+      mock(w.logger).error(/\[Exception error="ScriptError" error_class=ScriptError worker_class=AcksWorker backtrace=.*/)
+      w.do_work(header, nil, "msg", handler)
+    end
+
     it "should log exceptions from workers" do
       handler = Object.new
       header = Object.new


### PR DESCRIPTION
I found that sneakers worker becomes frozen after raised NotImplementedError.
Code to reproduce:
```ruby
class MyWorker
  include Sneakers::Worker

  from_queue  'lolwut'

  def work(msg)
    raise NotImplementedError
    ack!
  end
```
This PR fixes it.