### PR TITLE
Allow handlers to configure queue

### DIFF
--- a/examples/max_retry_handler.rb
+++ b/examples/max_retry_handler.rb
@@ -33,12 +33,7 @@ WORKER_OPTIONS = {
 #
 class MaxRetryWorker
   include Sneakers::Worker
-  from_queue 'downloads',
-      WORKER_OPTIONS.merge({
-                             :arguments => {
-                               :'x-dead-letter-exchange' => 'downloads-retry'
-                             },
-                           })
+  from_queue 'downloads', WORKER_OPTIONS
 
   def work(msg)
     logger.info("MaxRetryWorker rejecting msg: #{msg.inspect}")
@@ -52,12 +47,7 @@ end
 # see the message once.
 class SucceedingWorker
   include Sneakers::Worker
-  from_queue 'uploads',
-      WORKER_OPTIONS.merge({
-                             :arguments => {
-                               :'x-dead-letter-exchange' => 'uploads-retry'
-                             },
-                           })
+  from_queue 'uploads', WORKER_OPTIONS
 
   def work(msg)
     logger.info("SucceedingWorker succeeding on msg: #{msg.inspect}")

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -82,6 +82,15 @@ module Sneakers
 
       end
 
+      def self.configure_queue name, opts
+        retry_name = opts[:retry_exchange] || "#{name}-retry"
+        opts.merge(
+          arguments: {
+            'x-dead-letter-exchange': retry_name
+          }
+        )
+      end
+
       def acknowledge(hdr, props, msg)
         @channel.acknowledge(hdr.delivery_tag, false)
       end

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -31,6 +31,12 @@ class Sneakers::Queue
     routing_key = @opts[:routing_key] || @name
     routing_keys = [*routing_key]
 
+    handler_klass = worker.opts[:handler] || Sneakers::CONFIG.fetch(:handler)
+    # Configure options if needed
+    if handler_klass.respond_to?(:configure_queue)
+      @opts[:queue_options] = handler_klass.configure_queue(@name, @opts[:queue_options])
+    end
+
     # TODO: get the arguments from the handler? Retry handler wants this so you
     # don't have to line up the queue's dead letter argument with the exchange
     # you'll create for retry.
@@ -50,7 +56,6 @@ class Sneakers::Queue
     # has the same configuration as the worker. Also pass along the exchange and
     # queue in case the handler requires access to them (for things like binding
     # retry queues, etc).
-    handler_klass = worker.opts[:handler] || Sneakers::CONFIG.fetch(:handler)
     handler = handler_klass.new(@channel, queue, worker.opts)
 
     @consumer = queue.subscribe(block: false, manual_ack: @opts[:ack]) do | delivery_info, metadata, msg |

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -37,9 +37,6 @@ class Sneakers::Queue
       @opts[:queue_options] = handler_klass.configure_queue(@name, @opts[:queue_options])
     end
 
-    # TODO: get the arguments from the handler? Retry handler wants this so you
-    # don't have to line up the queue's dead letter argument with the exchange
-    # you'll create for retry.
     queue = @channel.queue(@name, @opts[:queue_options])
 
     if exchange_name.length > 0


### PR DESCRIPTION
Adds a hook on handler class to allow configuration of options before queue creation and handler instantiation.

This allow Maxretry handler to auto-configure the required dead letter exchange on the worker queue.