### PR TITLE
Maxretry use headers for failure info

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -134,18 +134,32 @@ module Sneakers
             error: reason.to_s,
             num_attempts: num_attempts,
             failed_at: Time.now.iso8601,
-            payload: Base64.encode64(msg.to_s),
-            properties: Base64.encode64(props.to_json)
+            properties: props.to_hash
           }.tap do |hash|
             if reason.is_a?(Exception)
               hash[:error_class] = reason.class.to_s
               hash[:error_message] = "#{reason}"
               if reason.backtrace
-                hash[:backtrace] = reason.backtrace.take(10).join(', ')
+                hash[:backtrace] = reason.backtrace.take(10)
               end
             end
-          end.to_json
-          @error_exchange.publish(data, :routing_key => hdr.routing_key)
+          end
+
+          # Preserve retry log in a list
+          if retry_info = props[:headers]['retry_info']
+            old_retry = JSON.parse retry_info rescue {error: "No retry info"}
+            old_retry = [old_retry] unless old_retry.is_a? Array
+            # Prevent old retry from nesting
+            data[:properties][:headers].delete 'retry_info'
+            data = old_retry.unshift data
+          end
+
+          @error_exchange.publish msg, {
+            routing_key: hdr.routing_key,
+            headers: {
+              retry_info: data.to_json
+            }
+          }
           @channel.acknowledge(hdr.delivery_tag, false)
           # TODO: metrics
         end


### PR DESCRIPTION
Fixes #350 and #337 

This leaves the payload and properties unobscured in the dead message and allows messages to be requeued using shovel.

Inspired by https://github.com/eetay/sneakers-retry.
Additionally, retry history from a requeued dead message is maintained in an array and nesting is prevented.

#### Dead Job History
```
retry_info: [
  {
    "error": "reject",
    "num_attempts": 6,
    "failed_at": "2018-12-08T17:48:51+00:00",
    "properties": {
      "content_type": "application/octet-stream",
      "headers": {
      ...
      },
      "delivery_mode": 2,
      "priority": 0
    }
  },
  {
    "error": "reject",
    "num_attempts": 6,
    "failed_at": "2018-12-08T17:47:59+00:00",
    "properties": {
      "content_type": "application/octet-stream",
      "headers": {
      ...
      },
      "delivery_mode": 2,
      "priority": 0
    }
  }
]
```