### PR TITLE
Add Changelog for new release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,39 @@
 # Sneakers Change Log
 
+## Changes Between 2.10.0 and 2.11.0
+
+This releases includes bug fixes, support for more queue-binding options, better
+management of the Bunny dependency, and improved documentation. Following is a
+list of the notable changes:
+
+### Rescue from ScriptError
+
+Fixes a bug that would cause Sneakers workers to freeze if an exception
+descending from `ScriptError`, such as `NotImplementedError`, is raised
+
+Contributed by @sharshenov
+
+GitHub Pull Request: [373](https://github.com/jondot/sneakers/pull/373)
+
+### Loosen Bunny dependency to minor version
+
+The dependency on Bunny is now pinned to the minor version instead of patch,
+allowing users to benefit from non-breaking updates to Bunny without having to
+wait for a Sneakers release.
+
+Contributed by @olivierlacan
+
+GitHub Pull Request: [#372](https://github.com/jondot/sneakers/pull/372)
+
+### Support `:queue_arguments` on bind
+
+It is now possible to set arguments on a queue when connecting to a headers
+exchange
+
+Contributed by @nerikj
+
+GitHub Pull Request: [#358](https://github.com/jondot/sneakers/pull/358)
+
 ## Changes Between 2.8.0 and 2.10.0
 
 This release contains **minor breaking API changes**.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,12 @@ Contributed by @nerikj
 
 GitHub Pull Request: [#358](https://github.com/jondot/sneakers/pull/358)
 
+### Other contributions
+
+This release also contains contributions from @ivan-kolmychek (bumping up Bunny
+dependency), @michaelklishin (improving code style), and @darren987469 (adding
+examples to the README)
+
 ## Changes Between 2.8.0 and 2.10.0
 
 This release contains **minor breaking API changes**.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,7 @@ Contributed by @olivierlacan
 
 GitHub Pull Request: [#372](https://github.com/jondot/sneakers/pull/372)
 
-### Support `:queue_arguments` on bind
+### Support `:bind_arguments` on bind
 
 It is now possible to set arguments on a queue when connecting to a headers
 exchange


### PR DESCRIPTION
List changes between release 2.10.0 and upcoming release (assuming it will be named 2.11.0), as discussed here: https://github.com/jondot/sneakers/pull/372#issuecomment-445372953

Notes:

  1. There were 3 successive commits dealing with the Bunny dependency: [bump 2.9.2 to 2.10.0](https://github.com/jondot/sneakers/commit/248792257a2d31783c61f70c9083395cce8908db), [bump to 2.11.x](https://github.com/jondot/sneakers/commit/7c059d1490e4dde43f98b801c38e4e0df7ac458c) and, finally, [bump and loosen dependency to ~> 2.12](https://github.com/jondot/sneakers/commit/d679f8740fa3710a91617b748b69ba4cd61c23a8). I choose to mention only the last one, as it supersedes the previous two. I did mention the contributors though.
  2. Non-functional changes (docs improvement, code style) are included in one summary, mentioning the contributors: even though they do not affect the functionality, so they do not require a detailed description in the changelog, these contributions do deserve credit
  3. I did not bump up the Sneakers version, as this should be done by maintainers upon releasing, and I assumed the new release will be called `2.11.0`. I think it's the appropriate version number, but if this changes the heading in the changelog must also be changed

Thanks everybody for the great work, hoping to see the new release in Rubygems soon :)
