### PR TITLE
support multiple exchanges for queue

### DIFF
--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -107,7 +107,6 @@ describe Sneakers::Queue do
         mock(@mkqueue_nondurable).subscribe(:block => false, :manual_ack => true)
 
         q.subscribe(@mkworker)
-        myqueue = q.instance_variable_get(:@queue)
       end
     end
 
@@ -134,6 +133,101 @@ describe Sneakers::Queue do
 
         stub(@mkqueue).subscribe
         q = Sneakers::Queue.new("downloads", queue_vars)
+        q.subscribe(@mkworker)
+      end
+    end
+
+    describe "#subscribe with multiple exchanges" do
+      before do
+        @mkex2 = Object.new
+        # expect default exchange and sneakers exchange
+        queue_vars[:exchanges] = [
+          {
+            :exchange => "sneakers",
+            :exchange_options => {
+              :type => :direct,
+              durable: true,
+              :arguments => { 'x-arg' => 'value' }
+            }
+          },
+          {
+            :exchange => "sneakers2",
+            :exchange_options => {
+              :type => :direct,
+              durable: true,
+              :arguments => { 'x-arg' => 'value' }
+            }
+          }
+        ]
+        mock(@mkchan).exchange("sneakers",
+                               :type => :direct,
+                               :durable => true,
+                               :arguments => {"x-arg" => "value"}){ @mkex2 }
+        mock(@mkchan).exchange("sneakers2",
+                               :type => :direct,
+                               :durable => true,
+                               :arguments => { 'x-arg' => 'value' }){ @mkex }
+      end
+
+      it "should setup a bunny queue according to configuration values" do
+        mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
+        q = Sneakers::Queue.new("downloads", queue_vars)
+
+        mock(@mkqueue).bind(@mkex, :routing_key => "downloads")
+        mock(@mkqueue).bind(@mkex2, :routing_key => "downloads")
+        mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
+
+        q.subscribe(@mkworker)
+      end
+
+      it "supports multiple routing_keys" do
+        mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
+        q = Sneakers::Queue.new("downloads",
+                                queue_vars.merge(:routing_key => ["alpha", "beta"]))
+
+        mock(@mkqueue).bind(@mkex, :routing_key => "alpha")
+        mock(@mkqueue).bind(@mkex, :routing_key => "beta")
+        mock(@mkqueue).bind(@mkex2, :routing_key => "alpha")
+        mock(@mkqueue).bind(@mkex2, :routing_key => "beta")
+        mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
+
+        q.subscribe(@mkworker)
+      end
+
+      it "supports setting arguments when binding" do
+        mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
+        q = Sneakers::Queue.new("downloads",
+                                queue_vars.merge(:bind_arguments => { "os" => "linux", "cores" => 8 }))
+
+        mock(@mkqueue).bind(@mkex, :routing_key => "downloads", :arguments => { "os" => "linux", "cores" => 8 })
+        mock(@mkqueue).bind(@mkex2, :routing_key => "downloads", :arguments => { "os" => "linux", "cores" => 8 })
+        mock(@mkqueue).subscribe(:block => false, :manual_ack => true)
+
+        q.subscribe(@mkworker)
+      end
+
+      it "will use whatever handler the worker specifies" do
+        mock(@mkchan).queue("downloads", :durable => true) { @mkqueue }
+        @handler = Object.new
+        worker_opts = { :handler => @handler }
+        stub(@mkworker).opts { worker_opts }
+        mock(@handler).new(@mkchan, @mkqueue, worker_opts).once
+
+        stub(@mkqueue).bind
+        stub(@mkqueue).subscribe
+        q = Sneakers::Queue.new("downloads", queue_vars)
+        q.subscribe(@mkworker)
+      end
+
+      it "creates a non-durable queue if :queue_durable => false" do
+        mock(@mkchan).queue("test_nondurable", :durable => false) { @mkqueue_nondurable }
+        queue_vars[:queue_options][:durable] = false
+        q = Sneakers::Queue.new("test_nondurable", queue_vars)
+
+        mock(@mkqueue_nondurable).bind(@mkex, :routing_key => "test_nondurable")
+        mock(@mkqueue_nondurable).bind(@mkex2, :routing_key => "test_nondurable")
+        mock(@mkqueue_nondurable).subscribe(:block => false, :manual_ack => true)
+
         q.subscribe(@mkworker)
       end
     end


### PR DESCRIPTION
Hi there, 

in our project we tried to use two delivery strategies for one queue. We want to connect our queue to a exchange of type direct and to another exchange of type fanout. So we changed the subscrive method of the queue object to support multiple exchanges. Please have a look at the code and merge it if it's fine. ;-)

Kind regards, 
Steve