### PR TITLE
Allow re-raise configured exceptions to worker

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -43,6 +43,7 @@ module Sneakers
       :ack                => true,
       :heartbeat          => 30,
       :hooks              => {},
+      :raise_exceptions   => [],
       :exchange           => 'sneakers',
       :exchange_options   => EXCHANGE_OPTION_DEFAULTS,
       :queue_options      => QUEUE_OPTION_DEFAULTS

--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -72,6 +72,8 @@ module Sneakers
           end
           res = block_to_call.call(deserialized_msg, delivery_info, metadata, handler)
         end
+      rescue *opts[:raise_exceptions] => ex
+        raise
       rescue StandardError, ScriptError => ex
         res = :error
         error = ex

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -193,6 +193,7 @@ describe Sneakers::Worker do
             :arguments => {}
           },
           :hooks => {},
+          :raise_exceptions => [],
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 30,
           :amqp_heartbeat => 30
@@ -231,6 +232,7 @@ describe Sneakers::Worker do
             :arguments => { 'x-arg' => 'value' }
           },
           :hooks => {},
+          :raise_exceptions => [],
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 5,
           :amqp_heartbeat => 30
@@ -269,6 +271,7 @@ describe Sneakers::Worker do
             :arguments => { 'x-arg2' => 'value2' }
           },
           :hooks => {},
+          :raise_exceptions => [],
           :handler => Sneakers::Handlers::Oneshot,
           :heartbeat => 30,
           :amqp_heartbeat => 30


### PR DESCRIPTION
If we need process some exceptions inside worker
before
```
rescue StandardError, ScriptError => ex
```
