### PR TITLE
CI: Use 2.6.3, 2.5.5, 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ before_script:
   - until sudo lsof -i:5672; do echo "Waiting for RabbitMQ to start..."; sleep 1; done
 rvm:
   - ruby-head
-  - "2.6.1"
-  - "2.5.3"
-  - "2.4.5"
+  - "2.6.3"
+  - "2.5.5"
+  - "2.4.6"
   - "2.3.8"
 matrix:
   include:
-    - rvm: "2.6.0"
+    - rvm: "2.6.3"
       env: INTEGRATION_LOG=1 INTEGRATION=1
   allow_failures:
     rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: true
 language: ruby
 cache: bundler


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known