### PR TITLE
Allowing sneakers to be run without an exchange

### DIFF
--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -26,7 +26,10 @@ class Sneakers::Queue
     @channel.prefetch(@opts[:prefetch])
 
     exchange_name = @opts[:exchange]
-    @exchange = @channel.exchange(exchange_name, @opts[:exchange_options])
+
+    unless exchange_name.nil?
+      @exchange = @channel.exchange(exchange_name, @opts[:exchange_options])
+    end
 
     routing_key = @opts[:routing_key] || @name
     routing_keys = [*routing_key]
@@ -39,12 +42,16 @@ class Sneakers::Queue
 
     queue = @channel.queue(@name, @opts[:queue_options])
 
-    if exchange_name.length > 0
-      routing_keys.each do |key|
-        if @opts[:bind_arguments]
-          queue.bind(@exchange, routing_key: key, arguments: @opts[:bind_arguments])
-        else
-          queue.bind(@exchange, routing_key: key)
+    # If no exchange has been passed, do not try to create any binding on the queue
+    # We will work on the queue directly
+    if @exchange
+      if exchange_name.length > 0
+        routing_keys.each do |key|
+          if @opts[:bind_arguments]
+            queue.bind(@exchange, routing_key: key, arguments: @opts[:bind_arguments])
+          else
+            queue.bind(@exchange, routing_key: key)
+          end
         end
       end
     end


### PR DESCRIPTION
This is a basic, minimal draft for implementing this feature : sneakers should (optionally) be able to run on a queue without having to mess at all with the exchange on which the queue is bound. This is important in configurations where the queue already exists and no authorizations are given on the exchange itself.

Passing explicitly `exchange =>nil` to the sneakers queue configuration will bypass the exchange handling part (until now, sneakers would crash in that configuration). It will not break the compatibility with configurations where a sneakers exchange is not given at all (it will default to 'sneakers' just as before). I've also run the tests and nothing's reported broken. I'm not familiar with sneakers source, but haven't found other parts of the source that could be impacted by these changes.