### PR TITLE
Fix Runner#stop

### DIFF
--- a/lib/sneakers/runner.rb
+++ b/lib/sneakers/runner.rb
@@ -12,8 +12,8 @@ module Sneakers
       @se.run
     end
 
-    def stop
-      @se.stop
+    def stop(stop_graceful=true)
+      @se.stop(stop_graceful)
     end
   end
 


### PR DESCRIPTION
### Before the fix
Any call to `Runner#stop` would raise an exception.
As a workaround, one could redefine `Runner#stop`, as described in issue #407 .
### Reason
The encapsulated `ServiceEngine` instance expects an argument (`stop_graceful`), which was not provided.
### The fix
Add an argument to `Runner`'s `stop` method, with the same name `stop_graceful` and use it for the delegation.

