### PR TITLE
Zeitwerk mode

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -10,7 +10,11 @@ namespace :sneakers do
     Rake::Task['environment'].invoke
 
     if defined?(::Rails)
-      ::Rails.application.eager_load!
+      if defined?(::Zeitwerk)
+        ::Zeitwerk::Loader.eager_load_all
+      else
+        ::Rails.application.eager_load!
+      end
     end
 
     if ENV["WORKERS"].nil?


### PR DESCRIPTION
Resolves #396 

Rails 6.0 provides Zeitwerk mode and uses different eager load logic: it calls `::Zeitwerk::Loader.eager_load_all` in `Rails::Application::Finisher`. So we need to call `eager_load_all` manually.