### PR TITLE
Use ERB in yaml in order to use env vars to control worker count/etc

### DIFF
--- a/lib/sneakers/spawner.rb
+++ b/lib/sneakers/spawner.rb
@@ -17,7 +17,6 @@ module Sneakers
       worker_config.keys.each do |group_name|
         workers = worker_config[group_name]['classes']
         workers = workers.join "," if workers.is_a?(Array)
-        p "WORKER COUNT = #{worker_config[group_name]["workers"].to_s}" 
         @pids << fork do
           @exec_hash = {"WORKERS"=> workers, "WORKER_COUNT" => worker_config[group_name]["workers"].to_s}
           Kernel.exec(@exec_hash, @exec_string)

--- a/lib/sneakers/spawner.rb
+++ b/lib/sneakers/spawner.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module Sneakers
   class Spawner
@@ -12,10 +13,11 @@ module Sneakers
       end
       @pids = []
       @exec_string = "bundle exec rake sneakers:run"
-      worker_config = YAML.load(File.read(worker_group_config_file))
+      worker_config = YAML.load(ERB.new(File.read(worker_group_config_file)).result)
       worker_config.keys.each do |group_name|
         workers = worker_config[group_name]['classes']
         workers = workers.join "," if workers.is_a?(Array)
+        p "WORKER COUNT = #{worker_config[group_name]["workers"].to_s}" 
         @pids << fork do
           @exec_hash = {"WORKERS"=> workers, "WORKER_COUNT" => worker_config[group_name]["workers"].to_s}
           Kernel.exec(@exec_hash, @exec_string)


### PR DESCRIPTION
We rely on the WorkerGroup yml file to divide our workers, but we lacked control over the worker count per group.

This PR is to enable use ENV vars (via erb interpolation)  inside the yml file. 