### PR TITLE
Change publisher message to use debug log level

### DIFF
--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -15,7 +15,7 @@ module Sneakers
       ensure_connection!
       to_queue = options.delete(:to_queue)
       options[:routing_key] ||= to_queue
-      Sneakers.logger.info {"publishing <#{msg}> to [#{options[:routing_key]}]"}
+      Sneakers.logger.debug {"publishing <#{msg}> to [#{options[:routing_key]}]"}
       @exchange.publish(ContentType.serialize(msg, options[:content_type]), options)
     end
 


### PR DESCRIPTION
Sneakers uses inconsistent log level for messages produced by worker and publisher: worker uses `debug`, but publisher uses `info`. I think it makes sense for them to use the same log level, so it will be easy to configure logger to the right log level.

Worker:
https://github.com/jondot/sneakers/blob/master/lib/sneakers/worker.rb#L123