### PR TITLE
Remove rake development dependency

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rabbitmq_http_api_client'
   gem.add_development_dependency 'redis'
 
-  gem.add_development_dependency 'rake', '~> 12.3'
   gem.add_development_dependency 'minitest', '~> 5.11'
   gem.add_development_dependency 'rr', '~> 1.2.1'
   gem.add_development_dependency 'unparser', '0.2.2' # keep below 0.2.5 for ruby 2.0 compat.


### PR DESCRIPTION
We already have it as runtime dependency.

[closes: #426]