### PR TITLE
Update and relax serverengine version dependency

### DIFF
--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'serverengine', '~> 2.1.0'
+  gem.add_dependency 'serverengine', '~> 2.1'
   gem.add_dependency 'bunny', '~> 2.14'
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_dependency 'thor'


### PR DESCRIPTION
The latest [serverengine version is 2.2.1](https://rubygems.org/gems/serverengine) The [serverengine changelog](https://github.com/treasure-data/serverengine/blob/master/Changelog) does not indicate any breaking changes and the tests are green. 

This PR relaxes the version dependency requirement to allow all minor version updates.
