### PR TITLE
Update to new Minitest spec syntax

### DIFF
--- a/spec/sneakers/cli_spec.rb
+++ b/spec/sneakers/cli_spec.rb
@@ -27,7 +27,7 @@ describe Sneakers::CLI do
           "--require=#{File.expand_path('../fixtures/require_worker.rb', File.dirname(__FILE__))}"
         ]}.join ''
 
-        out.must_match(/Workers.*:.*TitleScraper.*/)
+        _(out).must_match(/Workers.*:.*TitleScraper.*/)
 
       end
 
@@ -38,7 +38,7 @@ describe Sneakers::CLI do
           "--require=#{File.expand_path('../fixtures/require_worker.rb', File.dirname(__FILE__))}"
         ]}.join ''
 
-        out.must_match(/Log.*Console/)
+        _(out).must_match(/Log.*Console/)
       end
 
       it "should be able to run as daemonized process" do
@@ -49,13 +49,13 @@ describe Sneakers::CLI do
           "--require=#{File.expand_path('../fixtures/require_worker.rb', File.dirname(__FILE__))}"
         ]}.join ''
 
-        out.must_match(/sneakers.log/)
+        _(out).must_match(/sneakers.log/)
       end
     end
 
     it "should fail when no workers found" do
       out = capture_io{ Sneakers::CLI.start ['work', 'TitleScraper'] }.join ''
-      out.must_match(/Missing workers: TitleScraper/)
+      _(out).must_match(/Missing workers: TitleScraper/)
     end
 
     it "should run all workers when run without specifying any" do
@@ -64,7 +64,7 @@ describe Sneakers::CLI do
         "--require=#{File.expand_path("../fixtures/require_worker.rb", File.dirname(__FILE__))}"
       ]}.join ''
 
-      out.must_match(/Workers.*:.*TitleScraper.*/)
+      _(out).must_match(/Workers.*:.*TitleScraper.*/)
     end
 
     after do

--- a/spec/sneakers/concerns/logging_spec.rb
+++ b/spec/sneakers/concerns/logging_spec.rb
@@ -14,25 +14,25 @@ describe Sneakers::Concerns::Logging do
     end
 
     it "should configure a default logger when included" do
-      Foobar.logger.must_be_nil
+      _(Foobar.logger).must_be_nil
       Foobar.configure_logger
-      Foobar.logger.wont_be_nil
-      Foobar.logger.formatter.must_equal Sneakers::Support::ProductionFormatter
+      _(Foobar.logger).wont_be_nil
+      _(Foobar.logger.formatter).must_equal Sneakers::Support::ProductionFormatter
     end
 
     it "should supply accessible instance logger" do
-      Foobar.logger.must_be_nil
+      _(Foobar.logger).must_be_nil
       Foobar.configure_logger
       f = Foobar.new
-      f.logger.must_equal Foobar.logger
-      f.logger.wont_be_nil
+      _(f.logger).must_equal Foobar.logger
+      _(f.logger).wont_be_nil
     end
 
     it "should configure a given logger when specified" do
-      Foobar.logger.must_be_nil
+      _(Foobar.logger).must_be_nil
       log = Logger.new(STDOUT)
       Foobar.configure_logger(log)
-      Foobar.logger.must_equal log
+      _(Foobar.logger).must_equal log
     end
   end
 end

--- a/spec/sneakers/concerns/metrics_spec.rb
+++ b/spec/sneakers/concerns/metrics_spec.rb
@@ -14,24 +14,24 @@ describe Sneakers::Concerns::Metrics do
     end
 
     it "should configure a default logger when included" do
-      Foometrics.metrics.must_be_nil
+      _(Foometrics.metrics).must_be_nil
       Foometrics.configure_metrics
-      Foometrics.metrics.wont_be_nil
+      _(Foometrics.metrics).wont_be_nil
     end
 
     it "should supply accessible instance logger" do
-      Foometrics.metrics.must_be_nil
+      _(Foometrics.metrics).must_be_nil
       Foometrics.configure_metrics
       f = Foometrics.new
-      f.metrics.must_equal Foometrics.metrics
-      f.metrics.wont_be_nil
+      _(f.metrics).must_equal Foometrics.metrics
+      _(f.metrics).wont_be_nil
     end
 
     it "should configure a given metrics when specified" do
-      Foometrics.metrics.must_be_nil
+      _(Foometrics.metrics).must_be_nil
       o = Object.new
       Foometrics.configure_metrics(o)
-      Foometrics.metrics.must_equal o
+      _(Foometrics.metrics).must_equal o
     end
   end
 end

--- a/spec/sneakers/configuration_spec.rb
+++ b/spec/sneakers/configuration_spec.rb
@@ -10,7 +10,7 @@ describe Sneakers::Configuration do
       with_env('RABBITMQ_URL', url) do
         config = Sneakers::Configuration.new
         config.merge!({ :vhost => 'test_host', :connection => connection })
-        config.has_key?(:vhost).must_equal false
+        _(config.has_key?(:vhost)).must_equal false
       end
     end
 
@@ -18,7 +18,7 @@ describe Sneakers::Configuration do
       url = 'amqp://foo:bar@localhost:5672'
       config = Sneakers::Configuration.new
       config.merge!({ :amqp => url, :connection => connection })
-      config.has_key?(:vhost).must_equal false
+      _(config.has_key?(:vhost)).must_equal false
     end
   end
 
@@ -26,14 +26,14 @@ describe Sneakers::Configuration do
     it 'should assign a default value for :amqp' do
       with_env('RABBITMQ_URL', nil) do
         config = Sneakers::Configuration.new
-        config[:amqp].must_equal 'amqp://guest:guest@localhost:5672'
+        _(config[:amqp]).must_equal 'amqp://guest:guest@localhost:5672'
       end
     end
 
     it 'should assign a default value for :vhost' do
       with_env('RABBITMQ_URL', nil) do
         config = Sneakers::Configuration.new
-        config[:vhost].must_equal '/'
+        _(config[:vhost]).must_equal '/'
       end
     end
 
@@ -41,7 +41,7 @@ describe Sneakers::Configuration do
       url = 'amqp://foo:bar@localhost:5672'
       with_env('RABBITMQ_URL', url) do
         config = Sneakers::Configuration.new
-        config[:amqp].must_equal url
+        _(config[:amqp]).must_equal url
       end
     end
 
@@ -49,7 +49,7 @@ describe Sneakers::Configuration do
       url = 'amqp://foo:bar@localhost:5672/foobarvhost'
       with_env('RABBITMQ_URL', url) do
         config = Sneakers::Configuration.new
-        config[:vhost].must_equal 'foobarvhost'
+        _(config[:vhost]).must_equal 'foobarvhost'
       end
     end
 
@@ -59,7 +59,7 @@ describe Sneakers::Configuration do
         url = 'amqp://foo:bar@localhost:5672/testvhost'
         config = Sneakers::Configuration.new
         config.merge!({ :amqp => url })
-        config[:vhost].must_equal 'testvhost'
+        _(config[:vhost]).must_equal 'testvhost'
       end
     end
 
@@ -67,7 +67,7 @@ describe Sneakers::Configuration do
       url = 'amqp://foo:bar@localhost:5672/foobarvhost'
       config = Sneakers::Configuration.new
       config.merge!({ :amqp => url, :vhost => 'test_host' })
-      config[:vhost].must_equal 'test_host'
+      _(config[:vhost]).must_equal 'test_host'
     end
 
     it 'should use vhost option if it is specified' do
@@ -75,7 +75,7 @@ describe Sneakers::Configuration do
       with_env('RABBITMQ_URL', url) do
         config = Sneakers::Configuration.new
         config.merge!({ :vhost => 'test_host' })
-        config[:vhost].must_equal 'test_host'
+        _(config[:vhost]).must_equal 'test_host'
       end
     end
 
@@ -83,7 +83,7 @@ describe Sneakers::Configuration do
       url = 'amqp://foo:bar@localhost:5672'
       config = Sneakers::Configuration.new
       config.merge!({ :amqp => url })
-      config[:vhost].must_equal '/'
+      _(config[:vhost]).must_equal '/'
     end
   end
 

--- a/spec/sneakers/content_type_spec.rb
+++ b/spec/sneakers/content_type_spec.rb
@@ -15,7 +15,7 @@ describe Sneakers::ContentType do
         deserializer: ->(payload) { JSON.parse(payload) },
       )
 
-      Sneakers::ContentType.deserialize('{"foo":"bar"}', 'application/json').must_equal('foo' => 'bar')
+      _(Sneakers::ContentType.deserialize('{"foo":"bar"}', 'application/json')).must_equal('foo' => 'bar')
     end
   end
 
@@ -27,23 +27,23 @@ describe Sneakers::ContentType do
         deserializer: ->(_) {},
       )
 
-      Sneakers::ContentType.serialize({ 'foo' => 'bar' }, 'application/json').must_equal('{"foo":"bar"}')
+      _(Sneakers::ContentType.serialize({ 'foo' => 'bar' }, 'application/json')).must_equal('{"foo":"bar"}')
     end
 
     it 'passes the payload through by default' do
       payload = "just some text"
-      Sneakers::ContentType.serialize(payload, 'unknown/type').must_equal(payload)
-      Sneakers::ContentType.deserialize(payload, 'unknown/type').must_equal(payload)
-      Sneakers::ContentType.serialize(payload, nil).must_equal(payload)
-      Sneakers::ContentType.deserialize(payload, nil).must_equal(payload)
+      _(Sneakers::ContentType.serialize(payload, 'unknown/type')).must_equal(payload)
+      _(Sneakers::ContentType.deserialize(payload, 'unknown/type')).must_equal(payload)
+      _(Sneakers::ContentType.serialize(payload, nil)).must_equal(payload)
+      _(Sneakers::ContentType.deserialize(payload, nil)).must_equal(payload)
     end
 
     it 'passes the payload through if type not found' do
       Sneakers::ContentType.register(content_type: 'found/type', serializer: ->(_) {}, deserializer: ->(_) {})
       payload = "just some text"
 
-      Sneakers::ContentType.serialize(payload, 'unknown/type').must_equal(payload)
-      Sneakers::ContentType.deserialize(payload, 'unknown/type').must_equal(payload)
+      _(Sneakers::ContentType.serialize(payload, 'unknown/type')).must_equal(payload)
+      _(Sneakers::ContentType.deserialize(payload, 'unknown/type')).must_equal(payload)
     end
   end
 
@@ -56,26 +56,26 @@ describe Sneakers::ContentType do
       )
 
       ct = Sneakers::ContentType
-      ct.deserialize(ct.serialize('hello world', 'text/base64'), 'text/base64').must_equal('hello world')
+      _(ct.deserialize(ct.serialize('hello world', 'text/base64'), 'text/base64')).must_equal('hello world')
     end
 
     it 'requires a content type' do
-      proc { Sneakers::ContentType.register(serializer: -> { }, deserializer: -> { }) }.must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(serializer: -> { }, deserializer: -> { }) }).must_raise ArgumentError
     end
 
     it 'expects serializer and deserializer to be present' do
-      proc { Sneakers::ContentType.register(content_type: 'foo', deserializer: -> { }) }.must_raise ArgumentError
-      proc { Sneakers::ContentType.register(content_type: 'foo', serializer: -> { }) }.must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(content_type: 'foo', deserializer: -> { }) }).must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(content_type: 'foo', serializer: -> { }) }).must_raise ArgumentError
     end
 
     it 'expects serializer and deserializer to be a proc' do
-      proc { Sneakers::ContentType.register(content_type: 'foo', serializer: 'not a proc', deserializer: ->(_) { }) }.must_raise ArgumentError
-      proc { Sneakers::ContentType.register(content_type: 'foo', serializer: ->(_) {}, deserializer: 'not a proc' ) }.must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(content_type: 'foo', serializer: 'not a proc', deserializer: ->(_) { }) }).must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(content_type: 'foo', serializer: ->(_) {}, deserializer: 'not a proc' ) }).must_raise ArgumentError
     end
 
     it 'expects serializer and deserializer to have the correct arity' do
-      proc { Sneakers::ContentType.register(content_type: 'foo', serializer: ->(_,_) {}, deserializer: ->(_) {}) }.must_raise ArgumentError
-      proc { Sneakers::ContentType.register(content_type: 'foo', serializer: ->(_) {}, deserializer: ->() {} ) }.must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(content_type: 'foo', serializer: ->(_,_) {}, deserializer: ->(_) {}) }).must_raise ArgumentError
+      _(proc { Sneakers::ContentType.register(content_type: 'foo', serializer: ->(_) {}, deserializer: ->() {} ) }).must_raise ArgumentError
     end
   end
 end

--- a/spec/sneakers/publisher_spec.rb
+++ b/spec/sneakers/publisher_spec.rb
@@ -126,14 +126,14 @@ describe Sneakers::Publisher do
       it 'can handle an existing connection that is offline' do
         p = Sneakers::Publisher.new
         p.publish('test msg', my_vars)
-        p.instance_variable_get(:@bunny).must_equal @existing_session
+        _(p.instance_variable_get(:@bunny)).must_equal @existing_session
       end
 
       it 'can handle an existing connection that is online' do
         mock(@existing_session).connected? { true }
         p = Sneakers::Publisher.new
         p.publish('test msg', my_vars)
-        p.instance_variable_get(:@bunny).must_equal @existing_session
+        _(p.instance_variable_get(:@bunny)).must_equal @existing_session
       end
     end
 

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -161,7 +161,7 @@ describe Sneakers::Queue do
 
       it 'uses that object' do
         @q.subscribe(@mkworker)
-        @q.instance_variable_get(:@bunny).must_equal @external_connection
+        _(@q.instance_variable_get(:@bunny)).must_equal @external_connection
       end
     end
   end

--- a/spec/sneakers/runner_spec.rb
+++ b/spec/sneakers/runner_spec.rb
@@ -41,15 +41,15 @@ describe Sneakers::RunnerConfig do
       end
 
       it "must not have :log key" do
-        runner_config.reload_config!.has_key?(:log).must_equal false
+        _(runner_config.reload_config!.has_key?(:log)).must_equal false
       end
 
       it "must have :logger key as an instance of Logger" do
-        runner_config.reload_config![:logger].is_a?(Logger).must_equal true
+        _(runner_config.reload_config![:logger].is_a?(Logger)).must_equal true
       end
 
       it "must have :connection" do
-        runner_config.reload_config![:connection].is_a?(Object).must_equal true
+        _(runner_config.reload_config![:connection].is_a?(Object)).must_equal true
       end
     end
   end
@@ -59,11 +59,11 @@ describe Sneakers::RunnerConfig do
 
     describe "#reload_config!" do
       it "must not have :log key" do
-        runner_config.reload_config!.has_key?(:log).must_equal false
+        _(runner_config.reload_config!.has_key?(:log)).must_equal false
       end
 
       it "must have :logger key as an instance of Logger" do
-        runner_config.reload_config![:logger].is_a?(Logger).must_equal true
+        _(runner_config.reload_config![:logger].is_a?(Logger)).must_equal true
       end
     end
   end

--- a/spec/sneakers/sneakers_spec.rb
+++ b/spec/sneakers/sneakers_spec.rb
@@ -17,38 +17,38 @@ describe Sneakers do
 
   describe 'self' do
     it 'should have defaults set up' do
-      Sneakers::CONFIG[:log].must_equal(STDOUT)
+      _(Sneakers::CONFIG[:log]).must_equal(STDOUT)
     end
 
     it 'should configure itself' do
       Sneakers.configure
-      Sneakers.logger.wont_be_nil
-      Sneakers.configured?.must_equal(true)
+      _(Sneakers.logger).wont_be_nil
+      _(Sneakers.configured?).must_equal(true)
     end
   end
 
   describe '.daemonize!' do
     it 'should set a logger to a default info level and not daemonize' do
       Sneakers.daemonize!
-      Sneakers::CONFIG[:log].must_equal('sneakers.log')
-      Sneakers::CONFIG[:daemonize].must_equal(true)
-      Sneakers.logger.level.must_equal(Logger::INFO)
+      _(Sneakers::CONFIG[:log]).must_equal('sneakers.log')
+      _(Sneakers::CONFIG[:daemonize]).must_equal(true)
+      _(Sneakers.logger.level).must_equal(Logger::INFO)
     end
 
     it 'should set a logger to a level given that level' do
       Sneakers.daemonize!(Logger::DEBUG)
-      Sneakers.logger.level.must_equal(Logger::DEBUG)
+      _(Sneakers.logger.level).must_equal(Logger::DEBUG)
     end
   end
 
 
   describe '.clear!' do
     it 'must reset dirty configuration to default' do
-      Sneakers::CONFIG[:log].must_equal(STDOUT)
+      _(Sneakers::CONFIG[:log]).must_equal(STDOUT)
       Sneakers.configure(:log => 'foobar.log')
-      Sneakers::CONFIG[:log].must_equal('foobar.log')
+      _(Sneakers::CONFIG[:log]).must_equal('foobar.log')
       Sneakers.clear!
-      Sneakers::CONFIG[:log].must_equal(STDOUT)
+      _(Sneakers::CONFIG[:log]).must_equal(STDOUT)
     end
   end
 
@@ -58,18 +58,18 @@ describe Sneakers do
 
     it 'should detect a string and configure a logger' do
       Sneakers.configure(:log => 'sneakers.log')
-      Sneakers.logger.kind_of?(logger_class).must_equal(true)
+      _(Sneakers.logger.kind_of?(logger_class)).must_equal(true)
     end
 
     it 'should detect a file-like thing and configure a logger' do
       Sneakers.configure(:log => STDOUT)
-      Sneakers.logger.kind_of?(logger_class).must_equal(true)
+      _(Sneakers.logger.kind_of?(logger_class)).must_equal(true)
     end
 
     it 'should detect an actual logger and configure it' do
       logger = Logger.new(STDOUT)
       Sneakers.configure(:log => logger)
-      Sneakers.logger.must_equal(logger)
+      _(Sneakers.logger).must_equal(logger)
     end
   end
 

--- a/spec/sneakers/support/utils_spec.rb
+++ b/spec/sneakers/support/utils_spec.rb
@@ -15,13 +15,13 @@ describe Sneakers::Utils do
     describe 'given a single class name' do
       describe 'without namespace' do
         it 'returns the worker class name' do
-          Sneakers::Utils.parse_workers('Foo').must_equal([[Foo],[]])
+          _(Sneakers::Utils.parse_workers('Foo')).must_equal([[Foo],[]])
         end
       end
 
       describe 'with namespace' do
         it 'returns the worker class name' do
-          Sneakers::Utils.parse_workers('Baz::Quux').must_equal([[Baz::Quux],[]])
+          _(Sneakers::Utils.parse_workers('Baz::Quux')).must_equal([[Baz::Quux],[]])
         end
       end
     end
@@ -29,14 +29,14 @@ describe Sneakers::Utils do
     describe 'given a list of class names' do
       describe 'without namespaces' do
         it 'returns all worker class names' do
-          Sneakers::Utils.parse_workers('Foo,Bar').must_equal([[Foo,Bar],[]])
+          _(Sneakers::Utils.parse_workers('Foo,Bar')).must_equal([[Foo,Bar],[]])
         end
       end
 
       describe 'with namespaces' do
         it 'returns all worker class names' do
           workers = Sneakers::Utils.parse_workers('Baz::Quux,Baz::Corge')
-          workers.must_equal([[Baz::Quux,Baz::Corge],[]])
+          _(workers).must_equal([[Baz::Quux,Baz::Corge],[]])
         end
       end
     end

--- a/spec/sneakers/worker_handlers_spec.rb
+++ b/spec/sneakers/worker_handlers_spec.rb
@@ -233,15 +233,15 @@ describe 'Handlers' do
 
             @error_exchange.extend MockPublish
             worker.do_work(@header, @props_with_x_death, :reject, @handler)
-            @error_exchange.called.must_equal(true)
-            @error_exchange.opts[:routing_key].must_equal('#')
+            _(@error_exchange.called).must_equal(true)
+            _(@error_exchange.opts[:routing_key]).must_equal('#')
             data = JSON.parse(@error_exchange.opts[:headers][:retry_info]) rescue nil
-            data.wont_be_nil
-            data['error'].must_equal('reject')
-            data['num_attempts'].must_equal(2)
-            @error_exchange.data.must_equal(:reject)
-            data['properties'].to_json.must_equal(@props_with_x_death.to_json)
-            Time.parse(data['failed_at']).wont_be_nil
+            _(data).wont_be_nil
+            _(data['error']).must_equal('reject')
+            _(data['num_attempts']).must_equal(2)
+            _(@error_exchange.data).must_equal(:reject)
+            _(data['properties'].to_json).must_equal(@props_with_x_death.to_json)
+            _(Time.parse(data['failed_at'])).wont_be_nil
           end
 
           it 'counts the number of attempts using the count key' do
@@ -250,15 +250,15 @@ describe 'Handlers' do
 
             @error_exchange.extend MockPublish
             worker.do_work(@header, props_with_x_death_count, :reject, @handler)
-            @error_exchange.called.must_equal(true)
-            @error_exchange.opts[:routing_key].must_equal('#')
+            _(@error_exchange.called).must_equal(true)
+            _(@error_exchange.opts[:routing_key]).must_equal('#')
             data = JSON.parse(@error_exchange.opts[:headers][:retry_info]) rescue nil
-            data.wont_be_nil
-            data['error'].must_equal('reject')
-            data['num_attempts'].must_equal(4)
-            @error_exchange.data.must_equal(:reject)
-            data['properties'].to_json.must_equal(props_with_x_death_count.to_json)
-            Time.parse(data['failed_at']).wont_be_nil
+            _(data).wont_be_nil
+            _(data['error']).must_equal('reject')
+            _(data['num_attempts']).must_equal(4)
+            _(@error_exchange.data).must_equal(:reject)
+            _(data['properties'].to_json).must_equal(props_with_x_death_count.to_json)
+            _(Time.parse(data['failed_at'])).wont_be_nil
           end
 
         end
@@ -301,17 +301,17 @@ describe 'Handlers' do
             @error_exchange.extend MockPublish
 
             worker.do_work(@header, @props_with_x_death, StandardError.new('boom!'), @handler)
-            @error_exchange.called.must_equal(true)
-            @error_exchange.opts[:routing_key].must_equal('#')
+            _(@error_exchange.called).must_equal(true)
+            _(@error_exchange.opts[:routing_key]).must_equal('#')
             data = JSON.parse(@error_exchange.opts[:headers][:retry_info]) rescue nil
-            data.wont_be_nil
-            data['error'].must_equal('boom!')
-            data['error_class'].must_equal(StandardError.to_s)
-            data['backtrace'].wont_be_nil
-            data['num_attempts'].must_equal(2)
-            @error_exchange.data.to_s.must_equal('boom!')
-            data['properties'].to_json.must_equal(@props_with_x_death.to_json)
-            Time.parse(data['failed_at']).wont_be_nil
+            _(data).wont_be_nil
+            _(data['error']).must_equal('boom!')
+            _(data['error_class']).must_equal(StandardError.to_s)
+            _(data['backtrace']).wont_be_nil
+            _(data['num_attempts']).must_equal(2)
+            _(@error_exchange.data.to_s).must_equal('boom!')
+            _(data['properties'].to_json).must_equal(@props_with_x_death.to_json)
+            _(Time.parse(data['failed_at'])).wont_be_nil
           end
         end
       end

--- a/spec/sneakers/worker_spec.rb
+++ b/spec/sneakers/worker_spec.rb
@@ -163,8 +163,8 @@ describe Sneakers::Worker do
     describe "builds an internal queue" do
       it "should build a queue with correct configuration given defaults" do
         @defaults_q = DefaultsWorker.new.queue
-        @defaults_q.name.must_equal('defaults')
-        @defaults_q.opts.to_hash.must_equal(
+        _(@defaults_q.name).must_equal('defaults')
+        _(@defaults_q.opts.to_hash).must_equal(
           :error_reporters => [Sneakers.error_reporters.last],
           :runner_config_file => nil,
           :metrics => nil,
@@ -201,8 +201,8 @@ describe Sneakers::Worker do
 
       it "should build a queue with given configuration" do
         @dummy_q = DummyWorker.new.queue
-        @dummy_q.name.must_equal('downloads')
-        @dummy_q.opts.to_hash.must_equal(
+        _(@dummy_q.name).must_equal('downloads')
+        _(@dummy_q.opts.to_hash).must_equal(
           :error_reporters => [Sneakers.error_reporters.last],
           :runner_config_file => nil,
           :metrics => nil,
@@ -239,8 +239,8 @@ describe Sneakers::Worker do
 
       it "should build a queue with correct configuration given deprecated exchange options" do
         @deprecated_exchange_opts_q = WithDeprecatedExchangeOptionsWorker.new.queue
-        @deprecated_exchange_opts_q.name.must_equal('defaults')
-        @deprecated_exchange_opts_q.opts.to_hash.must_equal(
+        _(@deprecated_exchange_opts_q.name).must_equal('defaults')
+        _(@deprecated_exchange_opts_q.opts.to_hash).must_equal(
           :error_reporters => [Sneakers.error_reporters.last],
           :runner_config_file => nil,
           :metrics => nil,
@@ -278,7 +278,7 @@ describe Sneakers::Worker do
 
     describe "initializes worker" do
       it "should generate a worker id" do
-        DummyWorker.new.id.must_match(/^worker-/)
+        _(DummyWorker.new.id).must_match(/^worker-/)
       end
     end
 
@@ -294,7 +294,7 @@ describe Sneakers::Worker do
 
       it "should build a queue with given connection" do
         @dummy_q = DummyWorker.new.queue
-        @dummy_q.opts[:connection].must_equal(@connection)
+        _(@dummy_q.opts[:connection]).must_equal(@connection)
       end
     end
   end
@@ -548,7 +548,7 @@ describe Sneakers::Worker do
       w = DummyWorker.new(@queue, TestPool.new)
       w.instance_variable_set(:@id, 'worker-id')
       m = w.log_msg('foo')
-      w.log_msg('foo').must_match(/\[worker-id\]\[#<Thread:.*>\]\[test-queue\]\[\{\}\] foo/)
+      _(w.log_msg('foo')).must_match(/\[worker-id\]\[#<Thread:.*>\]\[test-queue\]\[\{\}\] foo/)
     end
 
     describe '#worker_error' do

--- a/spec/sneakers/workergroup_spec.rb
+++ b/spec/sneakers/workergroup_spec.rb
@@ -59,7 +59,7 @@ describe Sneakers::WorkerGroup do
           engine.run
 
           workers = engine.instance_variable_get('@workers')
-          workers.first.opts[:connection].must_equal(connection)
+          _(workers.first.opts[:connection]).must_equal(connection)
         end
       end
     end


### PR DESCRIPTION
Global [expectations](http://docs.seattlerb.org/minitest/Minitest/Expectations.html) will be deprecated in Minitest 6.

This fixes the Mintest deprecations warnings.