### PR TITLE
Handle all exceptions

### DIFF
--- a/lib/sneakers/worker.rb
+++ b/lib/sneakers/worker.rb
@@ -83,15 +83,12 @@ module Sneakers
                      message: msg, delivery_info: delivery_info, metadata: metadata)
       ensure
         if @should_ack
-          if res == :ack
-            # note to future-self. never acknowledge multiple (multiple=true) messages under threads.
-            handler.acknowledge(delivery_info, metadata, msg)
-          elsif res == :error
-            handler.error(delivery_info, metadata, msg, error)
-          elsif res == :reject
-            handler.reject(delivery_info, metadata, msg)
-          elsif res == :requeue
-            handler.reject(delivery_info, metadata, msg, true)
+          case res
+          # note to future-self. never acknowledge multiple (multiple=true) messages under threads.
+          when :ack then handler.acknowledge(delivery_info, metadata, msg)
+          when :error then handler.error(delivery_info, metadata, msg, error)
+          when :reject then handler.reject(delivery_info, metadata, msg)
+          when :requeue then handler.reject(delivery_info, metadata, msg, true)
           else
             handler.noop(delivery_info, metadata, msg)
           end


### PR DESCRIPTION
Previously Sneakers was able to [handle `StandardError` and `ScriptError`](https://github.com/jondot/sneakers/pull/373) exceptions and their descendants. But there are more exceptions that could cause problems.

* `SystemStackError` (stack level too deep)
* `NoMemoryError`
* custom descendants of `Exception` (e.g. declared by gems)

In case of these exceptions, the handler is unable to report job state to the RabbitMQ. RabbitMQ keeps sending new jobs to the Sneakers until prefetch value reached. It makes Sneakers worker hang without processing any new message.

Closes #412 