### PR TITLE
Configure workers run by rake sneakers:run

### DIFF
--- a/lib/sneakers.rb
+++ b/lib/sneakers.rb
@@ -50,6 +50,14 @@ module Sneakers
     logger.level = loglevel
   end
 
+  def rake_worker_classes=(worker_classes)
+    @rake_worker_classes = worker_classes
+  end
+
+  def rake_worker_classes
+    @rake_worker_classes
+  end
+
   def logger=(logger)
     @logger = logger
   end

--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -17,11 +17,7 @@ namespace :sneakers do
       end
     end
 
-    if ENV["WORKERS"].nil?
-      workers = Sneakers::Worker::Classes
-    else
-      workers, missing_workers = Sneakers::Utils.parse_workers(ENV['WORKERS'])
-    end
+    workers, missing_workers = get_worker_classes
 
     unless missing_workers.nil? || missing_workers.empty?
       puts "Missing workers: #{missing_workers.join(', ')}" if missing_workers
@@ -37,6 +33,12 @@ Please set the classes of the workers you want to run like so:
   $ export WORKERS=MyWorker,FooWorker
   $ rake sneakers:run
 
+You can also configure them with
+  $ Sneakers.rake_worker_classes
+
+If you use something that responds to :call it will execute that
+
+Eventually, if nothing before applied, every class is used where you directly included the Sneakers::Worker
 EOF
       exit(1)
     end
@@ -44,5 +46,21 @@ EOF
     r = Sneakers::Runner.new(workers, opts)
 
     r.run
+  end
+
+  private
+
+  def get_worker_classes
+    if ENV["WORKERS"]
+      Sneakers::Utils.parse_workers(ENV['WORKERS'])
+    elsif Sneakers.rake_worker_classes
+      if Sneakers.rake_worker_classes.respond_to?(:call)
+        [Sneakers.rake_worker_classes.call]
+      else
+        [Sneakers.rake_worker_classes]
+      end
+    else
+      [Sneakers::Worker::Classes]
+    end || [[]]
   end
 end

--- a/spec/sneakers/tasks/sneakers_run_spec.rb
+++ b/spec/sneakers/tasks/sneakers_run_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require 'sneakers'
+require 'rake'
+require 'sneakers/tasks'
+
+describe '' do
+  class TestWorker
+    include Sneakers::Worker
+  end
+
+  class TestClass1 < TestWorker; end
+  class TestClass2 < TestWorker; end
+
+  def with_workers_env(workers)
+    undefine, restore = if ENV.key?('WORKERS')
+                        [false, ENV['WORKERS']]
+                      else
+                        true
+                      end
+    ENV['WORKERS'] = workers
+    yield
+  ensure
+    undefine ? ENV.delete('WORKERS') : ENV['WORKERS'] = restore
+  end
+
+  def with_rake_worker_classes(workers)
+    restore = Sneakers.rake_worker_classes
+    Sneakers.rake_worker_classes = workers
+    yield
+  ensure
+    Sneakers.rake_worker_classes = restore
+  end
+
+  let(:opts) { {} }
+
+  let :runner do
+    mock = Minitest::Mock.new
+    mock.expect(:run, nil)
+    mock.expect(:call, mock, [expected_workers, opts])
+    mock
+  end
+
+  let :run_rake_task do
+    Rake::Task['sneakers:run'].reenable
+    Rake.application.invoke_task 'sneakers:run'
+  end
+
+  describe 'without any settings' do
+    let(:expected_workers) { [TestWorker] }
+
+    it 'runs classes directly including the Worker' do
+      Sneakers::Runner.stub :new, runner do
+        run_rake_task
+      end
+      runner.verify
+    end
+  end
+
+  describe 'with rake_worker_classes set' do
+    let(:expected_workers) { [TestClass1, TestClass2] }
+
+    it 'runs the classes from the setting' do
+      with_rake_worker_classes([TestClass1, TestClass2]) do
+        Sneakers::Runner.stub :new, runner do
+          run_rake_task
+        end
+        runner.verify
+      end
+    end
+  end
+
+  describe 'with rake_worker_classes set, overriden by WORKERS env' do
+    let(:expected_workers) { [TestClass2] }
+
+    it 'runs the classes from the setting' do
+      with_rake_worker_classes([TestClass1, TestClass2]) do
+        with_workers_env('TestClass2') do
+          Sneakers::Runner.stub :new, runner do
+            run_rake_task
+          end
+          runner.verify
+        end
+      end
+    end
+  end
+
+  describe 'with rake_worker_classes responding to call' do
+    let(:expected_workers) { [TestClass1] }
+
+    it 'runs the classes from the setting' do
+      with_rake_worker_classes(-> { [TestClass1] }) do
+        Sneakers::Runner.stub :new, runner do
+          run_rake_task
+        end
+        runner.verify
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the possibility to configure the workers, run by rake sneakers:run through Sneakers.rake_worker_classes

It will use still the workers from ENV[WORKERS]
But you can delete that and instead set Sneakers.rake_worker_classes = [Class1, Class2, ...] or set something that responds to :call.
If nothing is set, still Sneakers::Classes are used.

We have the situation that we would like to set the classes run by the task directly from within our project through a setting and not use an ENV for it, since that must be known from outside of it.
On the other hand, we use a base class for our workers so that the default strategy with Sneakers::Classes is not working for us as well.
