### PR TITLE
maxretry configure_queue fix and specs

### DIFF
--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -84,7 +84,11 @@ module Sneakers
 
       def self.configure_queue(name, opts)
         retry_name = opts.fetch(:retry_exchange, "#{name}-retry")
-        opts.merge(arguments: { "x-dead-letter-exchange": retry_name })
+        queue_opts = { arguments: {} }.merge(opts[:queue_options])
+        if queue_opts[:arguments][:'x-dead-letter-exchange'].nil? && queue_opts[:arguments]['x-dead-letter-exchange'].nil?
+          queue_opts[:arguments][:'x-dead-letter-exchange'] = retry_name
+        end
+        queue_opts
       end
 
       def acknowledge(hdr, props, msg)

--- a/lib/sneakers/handlers/maxretry.rb
+++ b/lib/sneakers/handlers/maxretry.rb
@@ -84,11 +84,9 @@ module Sneakers
 
       def self.configure_queue(name, opts)
         retry_name = opts.fetch(:retry_exchange, "#{name}-retry")
-        queue_opts = { arguments: {} }.merge(opts[:queue_options])
-        if queue_opts[:arguments][:'x-dead-letter-exchange'].nil? && queue_opts[:arguments]['x-dead-letter-exchange'].nil?
-          queue_opts[:arguments][:'x-dead-letter-exchange'] = retry_name
-        end
-        queue_opts
+        opt_args = opts[:queue_options][:arguments] ? opts[:queue_options][:arguments].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo} : {}
+        opts[:queue_options][:arguments] = { :'x-dead-letter-exchange' => retry_name }.merge(opt_args)
+        opts[:queue_options]
       end
 
       def acknowledge(hdr, props, msg)

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -34,7 +34,7 @@ class Sneakers::Queue
     handler_klass = worker.opts[:handler] || Sneakers::CONFIG.fetch(:handler)
     # Configure options if needed
     if handler_klass.respond_to?(:configure_queue)
-      @opts[:queue_options] = handler_klass.configure_queue(@name, @opts[:queue_options])
+      @opts[:queue_options] = handler_klass.configure_queue(@name, @opts)
     end
 
     queue = @channel.queue(@name, @opts[:queue_options])

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov-rcov-text'
   gem.add_development_dependency 'guard', '~> 2.15'
   gem.add_development_dependency 'guard-minitest', '~> 2.4'
-  gem.add_development_dependency 'pry-byebug', '~> 3.7'
+  gem.add_development_dependency 'pry-byebug', '~> 3.2.0' # keep here for ruby 2.3 compat.
 end

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -21,6 +21,7 @@ describe Sneakers::Queue do
   end
 
   before do
+    Sneakers.clear!
     Sneakers.configure
 
     @mkworker = Object.new

--- a/spec/sneakers/worker_handlers_spec.rb
+++ b/spec/sneakers/worker_handlers_spec.rb
@@ -127,7 +127,7 @@ describe 'Handlers' do
         opts[:retry_max_times] = max_retries unless max_retries.nil?
       end
 
-      stub(queue).name { 'downloads' }
+      mock(queue).name { 'downloads' }
 
       @retry_exchange = Object.new
       @error_exchange = Object.new
@@ -396,7 +396,7 @@ describe 'Handlers' do
           let(:q) { Sneakers::Queue.new("downloads", @worker_opts) }
 
           it 'should configure queue with x-dead-letter-exchange and other args' do
-            mock(channel).queue("downloads", { :durable => 'true', :auto_delete => false, :exclusive => false, :arguments => { :"x-dead-letter-exchange" => "downloads-retry", 'x-arg' => 'value' } }).once { queue }
+            mock(channel).queue("downloads", { :durable => 'true', :auto_delete => false, :exclusive => false, :arguments => { :"x-dead-letter-exchange" => "downloads-retry", :"x-arg" => 'value' } }).once { queue }
             mock(queue).bind(@mkex, :routing_key => "downloads")
             mock(queue).subscribe(:block => false, :manual_ack => true)
 


### PR DESCRIPTION
maxretry configure_queue method fixed for following:
- retrieve retry-exchange from correct place on opts
- preserve other argument values
- do not overwrite user provided x-dead-letter-exchange value

resolves #442 