### PR TITLE
 Handle all exceptions except SignalException and SystemExit 

### DIFF
--- a/lib/sneakers/error_reporter.rb
+++ b/lib/sneakers/error_reporter.rb
@@ -16,7 +16,13 @@ module Sneakers
       Sneakers.error_reporters.each do |handler|
         begin
           handler.call(exception, self, context_hash)
-        rescue => inner_exception
+        rescue SignalException, SystemExit
+          # ServerEngine handles these exceptions, so they are not expected
+          # to be raised within the error reporter.
+          # Nevertheless, they are listed here to ensure that they are not
+          # caught by the rescue block below.
+          raise
+        rescue Exception => inner_exception
           Sneakers.logger.error '!!! ERROR REPORTER THREW AN ERROR !!!'
           Sneakers.logger.error inner_exception
           Sneakers.logger.error inner_exception.backtrace.join("\n") unless inner_exception.backtrace.nil?


### PR DESCRIPTION
Previously Sneakers was able to handle StandardError and ScriptError exceptions and their descendants. But there are more exceptions that could cause problems.

* SystemStackError (stack level too deep)
* NoMemoryError
* custom descendants of Exception (e.g. declared by gems)

In case of these exceptions, the handler is unable to report job state to the RabbitMQ. RabbitMQ keeps sending new jobs to the Sneakers until prefetch value reached. It makes Sneakers worker hang without processing any new message.