### PR TITLE
Use application's configured loader for eager loading

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -10,7 +10,7 @@ namespace :sneakers do
     Rake::Task['environment'].invoke
 
     if defined?(::Rails)
-      if defined?(::Zeitwerk)
+      if Rails.application.config.autoloader == :zeitwerk
         ::Zeitwerk::Loader.eager_load_all
       else
         ::Rails.application.eager_load!


### PR DESCRIPTION
We ran into an issue while running the latest from the master branch of sneakers, which includes https://github.com/jondot/sneakers/pull/411. This application is Rails 6 and uses the classic autoloader implementation, not Zeitwerk. When we installed another gem recently that uses Zeitwerk, our `bundle exec rake sneakers:run` task began resulting in this message:

```
Error: No workers found.
Please set the classes of the workers you want to run like so:

  $ export WORKERS=MyWorker,FooWorker
  $ rake sneakers:run

You can also configure them with
  $ Sneakers.rake_worker_classes

If you use something that responds to :call it will execute that

Eventually, if nothing before applied, every class is used where you directly included the Sneakers::Worker
```

Since this other gem we installed uses Zeitwerk, it brought in the dependency, and the `Zeitwerk` constant became defined. Using `::Rails.application.eager_load!` successfully loads our worker classes as expected.