### PR TITLE
Use Rails.autoloaders.zeitwerk_enabled? to check whether zeitwerk is rails autoloader

### DIFF
--- a/lib/sneakers/tasks.rb
+++ b/lib/sneakers/tasks.rb
@@ -10,7 +10,7 @@ namespace :sneakers do
     Rake::Task['environment'].invoke
 
     if defined?(::Rails)
-      if Rails.application.config.autoloader == :zeitwerk
+      if Rails.autoloaders.zeitwerk_enabled?
         ::Zeitwerk::Loader.eager_load_all
       else
         ::Rails.application.eager_load!


### PR DESCRIPTION
In [472](https://github.com/jondot/sneakers/pull/472) there was a change on the way the rake tasks detects and use's Rails autoloader, by using
```Rails.application.config.autoloader``` method call. This works
perfectly for projects with Rails version < 7. In Rails 7 projects this
method call fails as it seems that Rails.application.config.autoloader
is deprecated. Zeitwerk is the only autoloader available and is not
configurable anymore.
As per rails guides, there is a way to detect whether
Zeitwerk autoloader is enabled, by using the predicate
```Rails.autoloaders.zeitwerk_enabled?``` which is still present at Rails 7.